### PR TITLE
upgraded: Fix trailing slash in fleetlock URL causing errors

### DIFF
--- a/pkg/upgraded/fleetlock/client.go
+++ b/pkg/upgraded/fleetlock/client.go
@@ -25,7 +25,7 @@ func NewClient(url, group string) (*FleetlockClient, error) {
 	}
 
 	return &FleetlockClient{
-		url:   url,
+		url:   TrimTrailingSlash(url),
 		group: group,
 		appID: appID,
 	}, nil

--- a/pkg/upgraded/fleetlock/utils.go
+++ b/pkg/upgraded/fleetlock/utils.go
@@ -1,8 +1,11 @@
 package fleetlock
 
 import (
+	"strings"
+
 	systemdutils "github.com/heathcliff26/fleetlock/pkg/systemd-utils"
 	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/utils"
+	"k8s.io/klog/v2"
 )
 
 // Find the machine-id of the current node and generate a zincati appID from it.
@@ -17,4 +20,15 @@ func GetZincateAppID() (string, error) {
 		return "", err
 	}
 	return appID, nil
+}
+
+// When having // in a URL, it somehow converts the request from POST to GET.
+// See: https://github.com/golang/go/issues/69063
+// In general it could lead to unintended behaviour.
+func TrimTrailingSlash(url string) string {
+	res, found := strings.CutSuffix(url, "/")
+	if found {
+		klog.Warning("Removed trailing slash in URL, as this could lead to undefined behaviour")
+	}
+	return res
 }

--- a/pkg/upgraded/fleetlock/utils_test.go
+++ b/pkg/upgraded/fleetlock/utils_test.go
@@ -13,3 +13,10 @@ func TestGetZincateAppID(t *testing.T) {
 	assert.NoError(err, "Should succeed")
 	assert.NotEmpty(id, "Should return id")
 }
+
+func TestTrimTrailingSlash(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal("https://fleetlock.example.com", TrimTrailingSlash("https://fleetlock.example.com"), "Should not change URL")
+	assert.Equal("https://fleetlock.example.com", TrimTrailingSlash("https://fleetlock.example.com/"), "Should remove trailing /")
+}


### PR DESCRIPTION
A double slash in the URL causes the request method to become GET. Remove it to ensure the daemon can aquire the lock.

See: https://github.com/golang/go/issues/69063