### PR TITLE
upgraded: Prevent queue of upgrades based on outdated data

### DIFF
--- a/pkg/upgraded/daemon/daemon.go
+++ b/pkg/upgraded/daemon/daemon.go
@@ -10,19 +10,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/heathcliff26/kube-upgrade/pkg/constants"
 	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/config"
 	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/fleetlock"
 	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/kubeadm"
 	rpmostree "github.com/heathcliff26/kube-upgrade/pkg/upgraded/rpm-ostree"
 	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/utils"
-	"gopkg.in/yaml.v3"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -163,204 +157,10 @@ func (d *daemon) Run() error {
 	}()
 	go func() {
 		defer wg.Done()
-		d.watchForKubernetesUpgrade()
+		d.watchForNodeUpgrade()
 		slog.Info("Stopped watching for kubernetes upgrades")
 	}()
 
 	wg.Wait()
 	return nil
-}
-
-// Check for os upgrades and perform them if necessary.
-// Runs until context is cancelled
-func (d *daemon) watchForUpgrade() {
-	var needUpgrade bool
-	for {
-		d.retry(func() bool {
-			var err error
-			slog.Debug("Checking for upgrades via rpm-ostree")
-			needUpgrade, err = d.rpmostree.CheckForUpgrade()
-			if err == nil {
-				return true
-			}
-			slog.Error("Failed to check if there is a new upgrade", "err", err)
-			return false
-		})
-
-		if needUpgrade {
-			slog.Info("New upgrade is necessary, trying to start update")
-			d.retry(func() bool {
-				err := d.doUpgrade()
-				if err == nil {
-					return true
-				}
-				slog.Error("Failed to perform rpm-ostree upgrade", "err", err)
-				return false
-			})
-		} else {
-			slog.Debug("No upgrades found")
-		}
-
-		select {
-		case <-d.ctx.Done():
-			return
-		case <-time.After(d.checkInterval):
-		}
-	}
-}
-
-// Perform rpm-ostree upgrade
-func (d *daemon) doUpgrade() error {
-	d.upgrade.Lock()
-	defer d.upgrade.Unlock()
-
-	err := d.fleetlock.Lock()
-	if err != nil {
-		return fmt.Errorf("failed to aquire lock: %v", err)
-	}
-
-	err = d.rpmostree.Upgrade()
-	if err != nil {
-		return err
-	}
-
-	// This should not be reached, as rpmostree.Upgrade() reboots the node on success.
-	// I included it here mainly for completness sake.
-
-	d.releaseLock()
-	return nil
-}
-
-// Watch for kubernetes upgrades and preform them if necessary
-func (d *daemon) watchForKubernetesUpgrade() {
-	factory := informers.NewSharedInformerFactoryWithOptions(d.client, time.Minute, informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
-		opts.FieldSelector = fields.SelectorFromSet(fields.Set{"metadata.name": d.node}).String()
-	}))
-
-	informer := factory.Core().V1().Nodes().Informer()
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: d.checkNodeStatus,
-		UpdateFunc: func(_, newObj interface{}) {
-			d.checkNodeStatus(newObj)
-		},
-		DeleteFunc: func(_ interface{}) {
-			slog.Error("Node has been deleted from cluster")
-			d.cancel()
-		},
-	})
-	if err != nil {
-		slog.Error("Failed to add event handlers to kubernetes informer")
-		d.cancel()
-		return
-	}
-	err = informer.SetWatchErrorHandler(cache.DefaultWatchErrorHandler)
-	if err != nil {
-		slog.Error("Failed to set watch error handler to kubernetes informer")
-		d.cancel()
-		return
-	}
-	slog.Info("Watching for new kubernetes upgrades")
-	informer.Run(d.ctx.Done())
-}
-
-// Check if we need to upgrade the node and trigger the upgrade if needed
-func (d *daemon) checkNodeStatus(obj interface{}) {
-	node := obj.(*corev1.Node)
-
-	if !nodeNeedsUpgrade(node) {
-		return
-	}
-
-	d.retry(func() bool {
-		err := d.doNodeUpgrade(node)
-		if err == nil {
-			return true
-		}
-		slog.Error("Failed to upgrade node", "err", err, slog.String("node", node.GetName()))
-		return false
-	})
-}
-
-// Update the node by first rebasing to a new version and then upgrading kubernetes
-func (d *daemon) doNodeUpgrade(node *corev1.Node) error {
-	d.upgrade.Lock()
-	defer d.upgrade.Unlock()
-
-	version := node.Annotations[constants.KubernetesVersionAnnotation]
-	slog.Info("Attempting node upgrade to new kubernetes version", slog.String("node", node.GetName()), slog.String("version", version))
-
-	err := d.fleetlock.Lock()
-	if err != nil {
-		return fmt.Errorf("failed to aquire lock: %v", err)
-	}
-
-	if version != node.Status.NodeInfo.KubeletVersion {
-		slog.Info("Rebasing os to new kubernetes version", slog.String("version", version))
-		err := d.updateNodeStatus(constants.NodeUpgradeStatusRebasing)
-		if err != nil {
-			return fmt.Errorf("failed to update node status: %v", err)
-		}
-		err = d.rpmostree.Rebase(d.image + ":" + version)
-		if err != nil {
-			return fmt.Errorf("failed to rebase node: %v", err)
-		}
-	}
-
-	slog.Info("Updating node via kubeadm")
-
-	err = d.updateNodeStatus(constants.NodeUpgradeStatusUpgrading)
-	if err != nil {
-		return fmt.Errorf("failed to update node status: %v", err)
-	}
-
-	kubeadmConfigMap, err := d.client.CoreV1().ConfigMaps("kube-system").Get(d.ctx, "kubeadm-config", metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to fetch kubeadm-config: %v", err)
-	}
-	if kubeadmConfigMap.Data == nil {
-		return fmt.Errorf("kubeadm configmap contains no data")
-	}
-	var kubeadmConfig kubeadm.ClusterConfiguration
-	err = yaml.Unmarshal([]byte(kubeadmConfigMap.Data["ClusterConfiguration"]), &kubeadmConfig)
-	if err != nil {
-		return fmt.Errorf("failed to parse kubeadm-config: %v", err)
-	}
-
-	if version != kubeadmConfig.KubernetesVersion {
-		slog.Info("kubeadm-config kubernetesVersion does not match requested version, initializing upgrade", slog.String("kubernetesVersion", kubeadmConfig.KubernetesVersion), slog.String("version", version))
-		err = d.kubeadm.Apply(version)
-	} else {
-		slog.Debug("Cluster upgrade is already initialized, upgrading node")
-		err = d.kubeadm.Node()
-	}
-	if err != nil {
-		return fmt.Errorf("failed run kubeadm: %v", err)
-	}
-
-	err = d.updateNodeStatus(constants.NodeUpgradeStatusCompleted)
-	if err != nil {
-		return fmt.Errorf("failed to update node status: %v", err)
-	}
-
-	slog.Info("Finished node upgrade, releasing lock")
-	d.releaseLock()
-	return nil
-}
-
-// Update the kube-upgrade node status annotation with the given status
-func (d *daemon) updateNodeStatus(status string) error {
-	node, err := d.client.CoreV1().Nodes().Get(d.ctx, d.node, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	if node.Annotations == nil {
-		node.Annotations = make(map[string]string)
-	}
-	node.Annotations[constants.KubernetesUpgradeStatus] = status
-
-	_, err = d.client.CoreV1().Nodes().Update(d.ctx, node, metav1.UpdateOptions{})
-	if err == nil {
-		slog.Debug("Set node status", slog.String("status", status))
-	}
-	return err
 }

--- a/pkg/upgraded/daemon/daemon_test.go
+++ b/pkg/upgraded/daemon/daemon_test.go
@@ -9,14 +9,9 @@ import (
 	"time"
 
 	fleetlockclient "github.com/heathcliff26/fleetlock/pkg/server/client"
-	"github.com/heathcliff26/kube-upgrade/pkg/constants"
 	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/config"
 	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/fleetlock"
-	rpmostree "github.com/heathcliff26/kube-upgrade/pkg/upgraded/rpm-ostree"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestNewDaemon(t *testing.T) {
@@ -168,131 +163,6 @@ func TestRetry(t *testing.T) {
 	t.Cleanup(cancel)
 
 	assert.Equal(t, 6, count, "Should have run the function exactly 6 times")
-}
-
-func TestDoUpgrade(t *testing.T) {
-	t.Run("LockAlreadyReserved", func(t *testing.T) {
-		assert := assert.New(t)
-
-		client, srv := NewFakeFleetlockServer(t, http.StatusLocked)
-		t.Cleanup(func() {
-			srv.Close()
-		})
-		rpmOstreeCMD, err := rpmostree.New("testdata/exit-0.sh")
-		if !assert.NoError(err, "Failed to create rpm-ostree command") {
-			t.FailNow()
-		}
-
-		d := &daemon{
-			fleetlock: client,
-			rpmostree: rpmOstreeCMD,
-		}
-
-		err = d.doUpgrade()
-
-		assert.ErrorContains(err, "failed to aquire lock:")
-	})
-	t.Run("FailedOstreeUpgrade", func(t *testing.T) {
-		assert := assert.New(t)
-
-		client, srv := NewFakeFleetlockServer(t, http.StatusOK)
-		t.Cleanup(func() {
-			srv.Close()
-		})
-		rpmOstreeCMD, err := rpmostree.New("testdata/exit-1.sh")
-		if !assert.NoError(err, "Failed to create rpm-ostree command") {
-			t.FailNow()
-		}
-
-		d := &daemon{
-			fleetlock: client,
-			rpmostree: rpmOstreeCMD,
-		}
-
-		err = d.doUpgrade()
-
-		assert.Error(err, "Should exit with error")
-	})
-	// This case is kinda scetchy, as in reality the system would reboot on success, thus the method should never return
-	t.Run("Success", func(t *testing.T) {
-		assert := assert.New(t)
-
-		client, srv := NewFakeFleetlockServer(t, http.StatusOK)
-		t.Cleanup(func() {
-			srv.Close()
-		})
-		rpmOstreeCMD, err := rpmostree.New("testdata/exit-0.sh")
-		if !assert.NoError(err, "Failed to create rpm-ostree command") {
-			t.FailNow()
-		}
-
-		d := &daemon{
-			fleetlock: client,
-			rpmostree: rpmOstreeCMD,
-		}
-
-		err = d.doUpgrade()
-
-		assert.NoError(err, "Should succeed")
-	})
-}
-
-func TestUpdateNodeStatus(t *testing.T) {
-	tMatrix := []struct {
-		Name  string
-		Node  *corev1.Node
-		Error bool
-	}{
-		{
-			Name: "Success",
-			Node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "testnode",
-					Annotations: map[string]string{
-						constants.KubernetesUpgradeStatus: "unset",
-					},
-				},
-			},
-		},
-		{
-			Name: "NoAnnotations",
-			Node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "testnode",
-				},
-			},
-		},
-		{
-			Name:  "NoNode",
-			Error: true,
-		},
-	}
-
-	for _, tCase := range tMatrix {
-		t.Run(tCase.Name, func(t *testing.T) {
-			assert := assert.New(t)
-
-			c := fake.NewSimpleClientset()
-			d := &daemon{
-				client: c,
-				ctx:    context.Background(),
-			}
-			if tCase.Node != nil {
-				_, _ = c.CoreV1().Nodes().Create(context.Background(), tCase.Node, metav1.CreateOptions{})
-				d.node = tCase.Node.GetName()
-			} else {
-				d.node = "not-a-node"
-			}
-
-			if tCase.Error {
-				assert.Error(d.updateNodeStatus("new-status"), "Should fail")
-			} else {
-				assert.NoError(d.updateNodeStatus("new-status"), "Should succeed")
-				node, _ := c.CoreV1().Nodes().Get(context.Background(), d.node, metav1.GetOptions{})
-				assert.Equal("new-status", node.GetAnnotations()[constants.KubernetesUpgradeStatus], "Should have set status")
-			}
-		})
-	}
 }
 
 func cancelOnTimeout(t *testing.T, ctx context.Context, cancel context.CancelFunc) {

--- a/pkg/upgraded/daemon/nodes.go
+++ b/pkg/upgraded/daemon/nodes.go
@@ -1,0 +1,150 @@
+package daemon
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/heathcliff26/kube-upgrade/pkg/constants"
+	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/kubeadm"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Watch for node upgrades and preform them if necessary
+func (d *daemon) watchForNodeUpgrade() {
+	factory := informers.NewSharedInformerFactoryWithOptions(d.client, time.Minute, informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+		opts.FieldSelector = fields.SelectorFromSet(fields.Set{"metadata.name": d.node}).String()
+	}))
+
+	informer := factory.Core().V1().Nodes().Informer()
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: d.checkNodeStatus,
+		UpdateFunc: func(_, newObj interface{}) {
+			d.checkNodeStatus(newObj)
+		},
+		DeleteFunc: func(_ interface{}) {
+			slog.Error("Node has been deleted from cluster")
+			d.cancel()
+		},
+	})
+	if err != nil {
+		slog.Error("Failed to add event handlers to kubernetes informer")
+		d.cancel()
+		return
+	}
+	err = informer.SetWatchErrorHandler(cache.DefaultWatchErrorHandler)
+	if err != nil {
+		slog.Error("Failed to set watch error handler to kubernetes informer")
+		d.cancel()
+		return
+	}
+	slog.Info("Watching for new kubernetes upgrades")
+	informer.Run(d.ctx.Done())
+}
+
+// Check if we need to upgrade the node and trigger the upgrade if needed
+func (d *daemon) checkNodeStatus(obj interface{}) {
+	node := obj.(*corev1.Node)
+
+	if !nodeNeedsUpgrade(node) {
+		return
+	}
+
+	d.retry(func() bool {
+		err := d.doNodeUpgrade(node)
+		if err == nil {
+			return true
+		}
+		slog.Error("Failed to upgrade node", "err", err, slog.String("node", node.GetName()))
+		return false
+	})
+}
+
+// Update the node by first rebasing to a new version and then upgrading kubernetes
+func (d *daemon) doNodeUpgrade(node *corev1.Node) error {
+	d.upgrade.Lock()
+	defer d.upgrade.Unlock()
+
+	version := node.Annotations[constants.KubernetesVersionAnnotation]
+	slog.Info("Attempting node upgrade to new kubernetes version", slog.String("node", node.GetName()), slog.String("version", version))
+
+	err := d.fleetlock.Lock()
+	if err != nil {
+		return fmt.Errorf("failed to aquire lock: %v", err)
+	}
+
+	if version != node.Status.NodeInfo.KubeletVersion {
+		slog.Info("Rebasing os to new kubernetes version", slog.String("version", version))
+		err := d.updateNodeStatus(constants.NodeUpgradeStatusRebasing)
+		if err != nil {
+			return fmt.Errorf("failed to update node status: %v", err)
+		}
+		err = d.rpmostree.Rebase(d.image + ":" + version)
+		if err != nil {
+			return fmt.Errorf("failed to rebase node: %v", err)
+		}
+	}
+
+	slog.Info("Updating node via kubeadm")
+
+	err = d.updateNodeStatus(constants.NodeUpgradeStatusUpgrading)
+	if err != nil {
+		return fmt.Errorf("failed to update node status: %v", err)
+	}
+
+	kubeadmConfigMap, err := d.client.CoreV1().ConfigMaps("kube-system").Get(d.ctx, "kubeadm-config", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to fetch kubeadm-config: %v", err)
+	}
+	if kubeadmConfigMap.Data == nil {
+		return fmt.Errorf("kubeadm configmap contains no data")
+	}
+	var kubeadmConfig kubeadm.ClusterConfiguration
+	err = yaml.Unmarshal([]byte(kubeadmConfigMap.Data["ClusterConfiguration"]), &kubeadmConfig)
+	if err != nil {
+		return fmt.Errorf("failed to parse kubeadm-config: %v", err)
+	}
+
+	if version != kubeadmConfig.KubernetesVersion {
+		slog.Info("kubeadm-config kubernetesVersion does not match requested version, initializing upgrade", slog.String("kubernetesVersion", kubeadmConfig.KubernetesVersion), slog.String("version", version))
+		err = d.kubeadm.Apply(version)
+	} else {
+		slog.Debug("Cluster upgrade is already initialized, upgrading node")
+		err = d.kubeadm.Node()
+	}
+	if err != nil {
+		return fmt.Errorf("failed run kubeadm: %v", err)
+	}
+
+	err = d.updateNodeStatus(constants.NodeUpgradeStatusCompleted)
+	if err != nil {
+		return fmt.Errorf("failed to update node status: %v", err)
+	}
+
+	slog.Info("Finished node upgrade, releasing lock")
+	d.releaseLock()
+	return nil
+}
+
+// Update the kube-upgrade node status annotation with the given status
+func (d *daemon) updateNodeStatus(status string) error {
+	node, err := d.client.CoreV1().Nodes().Get(d.ctx, d.node, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
+	}
+	node.Annotations[constants.KubernetesUpgradeStatus] = status
+
+	_, err = d.client.CoreV1().Nodes().Update(d.ctx, node, metav1.UpdateOptions{})
+	if err == nil {
+		slog.Debug("Set node status", slog.String("status", status))
+	}
+	return err
+}

--- a/pkg/upgraded/daemon/nodes_test.go
+++ b/pkg/upgraded/daemon/nodes_test.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/heathcliff26/kube-upgrade/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestUpdateNodeStatus(t *testing.T) {
+	tMatrix := []struct {
+		Name  string
+		Node  *corev1.Node
+		Error bool
+	}{
+		{
+			Name: "Success",
+			Node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+					Annotations: map[string]string{
+						constants.KubernetesUpgradeStatus: "unset",
+					},
+				},
+			},
+		},
+		{
+			Name: "NoAnnotations",
+			Node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+				},
+			},
+		},
+		{
+			Name:  "NoNode",
+			Error: true,
+		},
+	}
+
+	for _, tCase := range tMatrix {
+		t.Run(tCase.Name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			c := fake.NewSimpleClientset()
+			d := &daemon{
+				client: c,
+				ctx:    context.Background(),
+			}
+			if tCase.Node != nil {
+				_, _ = c.CoreV1().Nodes().Create(context.Background(), tCase.Node, metav1.CreateOptions{})
+				d.node = tCase.Node.GetName()
+			} else {
+				d.node = "not-a-node"
+			}
+
+			if tCase.Error {
+				assert.Error(d.updateNodeStatus("new-status"), "Should fail")
+			} else {
+				assert.NoError(d.updateNodeStatus("new-status"), "Should succeed")
+				node, _ := c.CoreV1().Nodes().Get(context.Background(), d.node, metav1.GetOptions{})
+				assert.Equal("new-status", node.GetAnnotations()[constants.KubernetesUpgradeStatus], "Should have set status")
+			}
+		})
+	}
+}

--- a/pkg/upgraded/daemon/nodes_test.go
+++ b/pkg/upgraded/daemon/nodes_test.go
@@ -2,14 +2,110 @@ package daemon
 
 import (
 	"context"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/heathcliff26/kube-upgrade/pkg/constants"
+	rpmostree "github.com/heathcliff26/kube-upgrade/pkg/upgraded/rpm-ostree"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestDoNodeUpgrade(t *testing.T) {
+	t.Run("MutexAlreadyHeld", func(t *testing.T) {
+		d := &daemon{}
+
+		d.upgrade.Lock()
+		t.Cleanup(d.upgrade.Unlock)
+
+		assert.NoError(t, d.doNodeUpgrade(nil), "Should simply exit without doing anything")
+	})
+	t.Run("LockAlreadyReserved", func(t *testing.T) {
+		assert := assert.New(t)
+
+		client, srv := NewFakeFleetlockServer(t, http.StatusLocked)
+		t.Cleanup(func() {
+			srv.Close()
+		})
+
+		d := &daemon{
+			fleetlock: client,
+		}
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testnode",
+				Annotations: map[string]string{
+					constants.KubernetesVersionAnnotation: "v1.31.0",
+				},
+			},
+		}
+
+		err := d.doNodeUpgrade(node)
+
+		assert.ErrorContains(err, "failed to aquire lock:")
+	})
+	for name, succeed := range map[string]bool{
+		"FailedOstreeRebase":    false,
+		"SucceededOstreeRebase": true,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			client, srv := NewFakeFleetlockServer(t, http.StatusOK)
+			t.Cleanup(func() {
+				srv.Close()
+			})
+
+			path := "testdata/exit-1.sh"
+			if succeed {
+				path = "testdata/exit-0.sh"
+			}
+			rpmOstreeCMD, err := rpmostree.New(path)
+			if !assert.NoError(err, "Failed to create rpm-ostree command") {
+				t.FailNow()
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			t.Cleanup(cancel)
+
+			d := &daemon{
+				ctx:       ctx,
+				fleetlock: client,
+				rpmostree: rpmOstreeCMD,
+				client:    fake.NewSimpleClientset(),
+				node:      "testnode",
+			}
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: d.node,
+					Annotations: map[string]string{
+						constants.KubernetesVersionAnnotation: "v1.31.0",
+					},
+				},
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						KubeletVersion: "v1.30.4",
+					},
+				},
+			}
+			node, _ = d.client.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+
+			err = d.doNodeUpgrade(node)
+
+			if succeed {
+				assert.NoError(err, "Should exit without error")
+			} else {
+				assert.Error(err, "Should exit with error")
+			}
+			node, _ = d.client.CoreV1().Nodes().Get(context.Background(), node.GetName(), metav1.GetOptions{})
+			assert.Equal(constants.NodeUpgradeStatusRebasing, node.Annotations[constants.KubernetesUpgradeStatus], "Should have set correct node status")
+		})
+	}
+}
 
 func TestUpdateNodeStatus(t *testing.T) {
 	tMatrix := []struct {

--- a/pkg/upgraded/daemon/stream.go
+++ b/pkg/upgraded/daemon/stream.go
@@ -1,0 +1,67 @@
+package daemon
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// Check for os upgrades and perform them if necessary.
+// Runs until context is cancelled
+func (d *daemon) watchForUpgrade() {
+	var needUpgrade bool
+	for {
+		d.retry(func() bool {
+			var err error
+			slog.Debug("Checking for upgrades via rpm-ostree")
+			needUpgrade, err = d.rpmostree.CheckForUpgrade()
+			if err == nil {
+				return true
+			}
+			slog.Error("Failed to check if there is a new upgrade", "err", err)
+			return false
+		})
+
+		if needUpgrade {
+			slog.Info("New upgrade is necessary, trying to start update")
+			d.retry(func() bool {
+				err := d.doUpgrade()
+				if err == nil {
+					return true
+				}
+				slog.Error("Failed to perform rpm-ostree upgrade", "err", err)
+				return false
+			})
+		} else {
+			slog.Debug("No upgrades found")
+		}
+
+		select {
+		case <-d.ctx.Done():
+			return
+		case <-time.After(d.checkInterval):
+		}
+	}
+}
+
+// Perform rpm-ostree upgrade
+func (d *daemon) doUpgrade() error {
+	d.upgrade.Lock()
+	defer d.upgrade.Unlock()
+
+	err := d.fleetlock.Lock()
+	if err != nil {
+		return fmt.Errorf("failed to aquire lock: %v", err)
+	}
+
+	err = d.rpmostree.Upgrade()
+	if err != nil {
+		return err
+	}
+
+	// This should not be reached, as rpmostree.Upgrade() reboots the node on success.
+	// I included it here mainly for completness sake.
+
+	d.releaseLock()
+	return nil
+}

--- a/pkg/upgraded/daemon/stream.go
+++ b/pkg/upgraded/daemon/stream.go
@@ -46,7 +46,11 @@ func (d *daemon) watchForUpgrade() {
 
 // Perform rpm-ostree upgrade
 func (d *daemon) doUpgrade() error {
-	d.upgrade.Lock()
+	// There should ever only be one upgrade at a time and any upgrade comes with a reboot anyway.
+	// So the best option here is to just silently return if the lock is already held.
+	if !d.upgrade.TryLock() {
+		return nil
+	}
 	defer d.upgrade.Unlock()
 
 	err := d.fleetlock.Lock()

--- a/pkg/upgraded/daemon/stream_test.go
+++ b/pkg/upgraded/daemon/stream_test.go
@@ -51,6 +51,14 @@ func TestDoUpgrade(t *testing.T) {
 
 		assert.Error(err, "Should exit with error")
 	})
+	t.Run("MutexAlreadyHeld", func(t *testing.T) {
+		d := &daemon{}
+
+		d.upgrade.Lock()
+		t.Cleanup(d.upgrade.Unlock)
+
+		assert.NoError(t, d.doUpgrade(), "Should simply exit without doing anything")
+	})
 	// This case is kinda scetchy, as in reality the system would reboot on success, thus the method should never return
 	t.Run("Success", func(t *testing.T) {
 		assert := assert.New(t)

--- a/pkg/upgraded/daemon/stream_test.go
+++ b/pkg/upgraded/daemon/stream_test.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"net/http"
+	"testing"
+
+	rpmostree "github.com/heathcliff26/kube-upgrade/pkg/upgraded/rpm-ostree"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoUpgrade(t *testing.T) {
+	t.Run("LockAlreadyReserved", func(t *testing.T) {
+		assert := assert.New(t)
+
+		client, srv := NewFakeFleetlockServer(t, http.StatusLocked)
+		t.Cleanup(func() {
+			srv.Close()
+		})
+		rpmOstreeCMD, err := rpmostree.New("testdata/exit-0.sh")
+		if !assert.NoError(err, "Failed to create rpm-ostree command") {
+			t.FailNow()
+		}
+
+		d := &daemon{
+			fleetlock: client,
+			rpmostree: rpmOstreeCMD,
+		}
+
+		err = d.doUpgrade()
+
+		assert.ErrorContains(err, "failed to aquire lock:")
+	})
+	t.Run("FailedOstreeUpgrade", func(t *testing.T) {
+		assert := assert.New(t)
+
+		client, srv := NewFakeFleetlockServer(t, http.StatusOK)
+		t.Cleanup(func() {
+			srv.Close()
+		})
+		rpmOstreeCMD, err := rpmostree.New("testdata/exit-1.sh")
+		if !assert.NoError(err, "Failed to create rpm-ostree command") {
+			t.FailNow()
+		}
+
+		d := &daemon{
+			fleetlock: client,
+			rpmostree: rpmOstreeCMD,
+		}
+
+		err = d.doUpgrade()
+
+		assert.Error(err, "Should exit with error")
+	})
+	// This case is kinda scetchy, as in reality the system would reboot on success, thus the method should never return
+	t.Run("Success", func(t *testing.T) {
+		assert := assert.New(t)
+
+		client, srv := NewFakeFleetlockServer(t, http.StatusOK)
+		t.Cleanup(func() {
+			srv.Close()
+		})
+		rpmOstreeCMD, err := rpmostree.New("testdata/exit-0.sh")
+		if !assert.NoError(err, "Failed to create rpm-ostree command") {
+			t.FailNow()
+		}
+
+		d := &daemon{
+			fleetlock: client,
+			rpmostree: rpmOstreeCMD,
+		}
+
+		err = d.doUpgrade()
+
+		assert.NoError(err, "Should succeed")
+	})
+}


### PR DESCRIPTION
The listener triggers events multiple times, which causes a queue of updates.
Do not block on getting the lock, to ensure that no goroutines with stale
data try to run an update.

Make the daemon easier to read by separating stream and node upgrades.