### PR TITLE
constants: Rename annotations to be more unified

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,8 +1,13 @@
 package constants
 
 const (
-	KubernetesVersionAnnotation = "kubernetes-version.kube-upgrade.heathcliff.eu"
-	KubernetesUpgradeStatus     = "upgrade-status.kube-upgrade.heathcliff.eu"
+	baseDomain = "kube-upgrade.heathcliff.eu/"
+	nodePrefix = "node." + baseDomain
+)
+
+const (
+	NodeKubernetesVersion = nodePrefix + "kubernetesVersion"
+	NodeUpgradeStatus     = nodePrefix + "status"
 )
 
 const (

--- a/pkg/upgrade-controller/controller/controller.go
+++ b/pkg/upgrade-controller/controller/controller.go
@@ -186,16 +186,16 @@ func (c *controller) reconcileNodes(kubeVersion string, nodes []corev1.Node) (st
 			nodes[i].Annotations = make(map[string]string)
 		}
 
-		if nodes[i].Annotations[constants.KubernetesVersionAnnotation] == kubeVersion {
-			if nodes[i].Annotations[constants.KubernetesUpgradeStatus] != constants.NodeUpgradeStatusCompleted {
+		if nodes[i].Annotations[constants.NodeKubernetesVersion] == kubeVersion {
+			if nodes[i].Annotations[constants.NodeUpgradeStatus] != constants.NodeUpgradeStatusCompleted {
 				completed = false
 			}
 			continue
 		}
 
 		completed = false
-		nodes[i].Annotations[constants.KubernetesVersionAnnotation] = kubeVersion
-		nodes[i].Annotations[constants.KubernetesUpgradeStatus] = constants.NodeUpgradeStatusPending
+		nodes[i].Annotations[constants.NodeKubernetesVersion] = kubeVersion
+		nodes[i].Annotations[constants.NodeUpgradeStatus] = constants.NodeUpgradeStatusPending
 
 		needUpdate = true
 	}

--- a/pkg/upgrade-controller/controller/controller_test.go
+++ b/pkg/upgrade-controller/controller/controller_test.go
@@ -77,8 +77,8 @@ func TestReconcile(t *testing.T) {
 				groupInfra:   v1alpha1.PlanStatusWaiting,
 			},
 			ExpectedAnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusPending,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusPending,
 			},
 		},
 		{
@@ -119,8 +119,8 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			AnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedSummary: v1alpha1.PlanStatusProgressing,
 			ExpectedGroupStatus: map[string]string{
@@ -129,12 +129,12 @@ func TestReconcile(t *testing.T) {
 				groupInfra:   v1alpha1.PlanStatusProgressing,
 			},
 			ExpectedAnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedAnnotationsInfra: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusPending,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusPending,
 			},
 		},
 		{
@@ -175,12 +175,12 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			AnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			AnnotationsInfra: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedSummary: v1alpha1.PlanStatusProgressing,
 			ExpectedGroupStatus: map[string]string{
@@ -189,16 +189,16 @@ func TestReconcile(t *testing.T) {
 				groupInfra:   v1alpha1.PlanStatusComplete,
 			},
 			ExpectedAnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedAnnotationsInfra: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedAnnotationsCompute: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusPending,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusPending,
 			},
 		},
 		{
@@ -239,16 +239,16 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			AnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			AnnotationsInfra: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			AnnotationsCompute: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedSummary: v1alpha1.PlanStatusComplete,
 			ExpectedGroupStatus: map[string]string{
@@ -257,16 +257,16 @@ func TestReconcile(t *testing.T) {
 				groupInfra:   v1alpha1.PlanStatusComplete,
 			},
 			ExpectedAnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedAnnotationsInfra: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedAnnotationsCompute: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 		},
 		{
@@ -300,12 +300,12 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			AnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.30.4",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.30.4",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			AnnotationsCompute: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.30.4",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.30.4",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedSummary: v1alpha1.PlanStatusProgressing,
 			ExpectedGroupStatus: map[string]string{
@@ -313,12 +313,12 @@ func TestReconcile(t *testing.T) {
 				groupCompute: v1alpha1.PlanStatusWaiting,
 			},
 			ExpectedAnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusPending,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusPending,
 			},
 			ExpectedAnnotationsCompute: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.30.4",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.30.4",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 		},
 		{
@@ -352,12 +352,12 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			AnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			AnnotationsCompute: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.30.4",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.30.4",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedSummary: v1alpha1.PlanStatusProgressing,
 			ExpectedGroupStatus: map[string]string{
@@ -365,12 +365,12 @@ func TestReconcile(t *testing.T) {
 				groupCompute: v1alpha1.PlanStatusProgressing,
 			},
 			ExpectedAnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedAnnotationsCompute: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusPending,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusPending,
 			},
 		},
 		{
@@ -404,12 +404,12 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			AnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			AnnotationsCompute: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedSummary: v1alpha1.PlanStatusComplete,
 			ExpectedGroupStatus: map[string]string{
@@ -417,12 +417,12 @@ func TestReconcile(t *testing.T) {
 				groupCompute: v1alpha1.PlanStatusComplete,
 			},
 			ExpectedAnnotationsControl: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 			ExpectedAnnotationsCompute: map[string]string{
-				constants.KubernetesVersionAnnotation: "v1.31.0",
-				constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+				constants.NodeKubernetesVersion: "v1.31.0",
+				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
 		},
 	}

--- a/pkg/upgraded/daemon/nodes.go
+++ b/pkg/upgraded/daemon/nodes.go
@@ -75,7 +75,7 @@ func (d *daemon) doNodeUpgrade(node *corev1.Node) error {
 	}
 	defer d.upgrade.Unlock()
 
-	version := node.Annotations[constants.KubernetesVersionAnnotation]
+	version := node.Annotations[constants.NodeKubernetesVersion]
 	slog.Info("Attempting node upgrade to new kubernetes version", slog.String("node", node.GetName()), slog.String("version", version))
 
 	err := d.fleetlock.Lock()
@@ -147,7 +147,7 @@ func (d *daemon) updateNodeStatus(status string) error {
 	if node.Annotations == nil {
 		node.Annotations = make(map[string]string)
 	}
-	node.Annotations[constants.KubernetesUpgradeStatus] = status
+	node.Annotations[constants.NodeUpgradeStatus] = status
 
 	_, err = d.client.CoreV1().Nodes().Update(d.ctx, node, metav1.UpdateOptions{})
 	if err == nil {

--- a/pkg/upgraded/daemon/nodes_test.go
+++ b/pkg/upgraded/daemon/nodes_test.go
@@ -38,7 +38,7 @@ func TestDoNodeUpgrade(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "testnode",
 				Annotations: map[string]string{
-					constants.KubernetesVersionAnnotation: "v1.31.0",
+					constants.NodeKubernetesVersion: "v1.31.0",
 				},
 			},
 		}
@@ -83,7 +83,7 @@ func TestDoNodeUpgrade(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: d.node,
 					Annotations: map[string]string{
-						constants.KubernetesVersionAnnotation: "v1.31.0",
+						constants.NodeKubernetesVersion: "v1.31.0",
 					},
 				},
 				Status: corev1.NodeStatus{
@@ -102,7 +102,7 @@ func TestDoNodeUpgrade(t *testing.T) {
 				assert.Error(err, "Should exit with error")
 			}
 			node, _ = d.client.CoreV1().Nodes().Get(context.Background(), node.GetName(), metav1.GetOptions{})
-			assert.Equal(constants.NodeUpgradeStatusRebasing, node.Annotations[constants.KubernetesUpgradeStatus], "Should have set correct node status")
+			assert.Equal(constants.NodeUpgradeStatusRebasing, node.Annotations[constants.NodeUpgradeStatus], "Should have set correct node status")
 		})
 	}
 }
@@ -119,7 +119,7 @@ func TestUpdateNodeStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "testnode",
 					Annotations: map[string]string{
-						constants.KubernetesUpgradeStatus: "unset",
+						constants.NodeUpgradeStatus: "unset",
 					},
 				},
 			},
@@ -159,7 +159,7 @@ func TestUpdateNodeStatus(t *testing.T) {
 			} else {
 				assert.NoError(d.updateNodeStatus("new-status"), "Should succeed")
 				node, _ := c.CoreV1().Nodes().Get(context.Background(), d.node, metav1.GetOptions{})
-				assert.Equal("new-status", node.GetAnnotations()[constants.KubernetesUpgradeStatus], "Should have set status")
+				assert.Equal("new-status", node.GetAnnotations()[constants.NodeUpgradeStatus], "Should have set status")
 			}
 		})
 	}

--- a/pkg/upgraded/daemon/utils.go
+++ b/pkg/upgraded/daemon/utils.go
@@ -32,12 +32,12 @@ func nodeNeedsUpgrade(node *corev1.Node) bool {
 	if node.Annotations == nil {
 		return false
 	}
-	status := node.Annotations[constants.KubernetesUpgradeStatus]
+	status := node.Annotations[constants.NodeUpgradeStatus]
 	if status == constants.NodeUpgradeStatusCompleted {
 		return false
 	}
-	if _, ok := node.Annotations[constants.KubernetesVersionAnnotation]; !ok {
-		slog.Warn("Missing version annotation on node", slog.String("node", node.GetName()), slog.String("annotation", constants.KubernetesVersionAnnotation))
+	if _, ok := node.Annotations[constants.NodeKubernetesVersion]; !ok {
+		slog.Warn("Missing version annotation on node", slog.String("node", node.GetName()), slog.String("annotation", constants.NodeKubernetesVersion))
 		return false
 	}
 	return true

--- a/pkg/upgraded/daemon/utils_test.go
+++ b/pkg/upgraded/daemon/utils_test.go
@@ -49,8 +49,8 @@ func TestNodeNeedsUpgrade(t *testing.T) {
 			Node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						constants.KubernetesVersionAnnotation: "v1.31.0",
-						constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
+						constants.NodeKubernetesVersion: "v1.31.0",
+						constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 					},
 				},
 			},
@@ -61,7 +61,7 @@ func TestNodeNeedsUpgrade(t *testing.T) {
 			Node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						constants.KubernetesUpgradeStatus: constants.NodeUpgradeStatusPending,
+						constants.NodeUpgradeStatus: constants.NodeUpgradeStatusPending,
 					},
 				},
 			},
@@ -72,8 +72,8 @@ func TestNodeNeedsUpgrade(t *testing.T) {
 			Node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						constants.KubernetesVersionAnnotation: "v1.31.0",
-						constants.KubernetesUpgradeStatus:     constants.NodeUpgradeStatusPending,
+						constants.NodeKubernetesVersion: "v1.31.0",
+						constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusPending,
 					},
 				},
 			},


### PR DESCRIPTION
Rename annotations to use a unified scheme.
This could potentially break compatibility, though it should mostly just leave the old annotations behind without cleaning up.