### PR TITLE
upgraded: Rename config option image to stream

### DIFF
--- a/examples/upgraded-config.yaml
+++ b/examples/upgraded-config.yaml
@@ -4,7 +4,7 @@ logLevel: info
 # The path to the kubeconfig file
 kubeconfig: /etc/kubernetes/kubelet.conf
 # The container image repository for os rebases
-image: ghcr.io/heathcliff26/fcos-k8s
+stream: ghcr.io/heathcliff26/fcos-k8s
 # Configuration for fleetlock locking
 fleetlock:
   # Required: URL to the fleetlock server

--- a/pkg/upgraded/config/config.go
+++ b/pkg/upgraded/config/config.go
@@ -14,7 +14,7 @@ const (
 
 	DEFAULT_LOG_LEVEL       = "info"
 	DEFAULT_KUBECONFIG      = "/etc/kubernetes/kubelet.conf"
-	DEFAULT_IMAGE           = "ghcr.io/heathcliff26/fcos-k8s"
+	DEFAULT_STREAM          = "ghcr.io/heathcliff26/fcos-k8s"
 	DEFAULT_FLEETLOCK_GROUP = "default"
 	DEFAULT_RPM_OSTREE_PATH = "/usr/bin/rpm-ostree"
 	DEFAULT_KUBEADM_PATH    = "/usr/bin/kubeadm"
@@ -40,7 +40,7 @@ type Config struct {
 	// The path to the kubeconfig file, default is the kubelet config under "/etc/kubernetes/kubelet.conf"
 	Kubeconfig string `yaml:"kubeconfig,omitempty"`
 	// The container image repository for os rebases
-	Image string `yaml:"image,omitempty"`
+	Stream string `yaml:"stream,omitempty"`
 	// Configuration for fleetlock node locking
 	Fleetlock FleetlockConfig `yaml:"fleetlock"`
 	// The path to the rpm-ostree binary, default "/usr/bin/rpm-ostree"
@@ -82,7 +82,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		LogLevel:   DEFAULT_LOG_LEVEL,
 		Kubeconfig: DEFAULT_KUBECONFIG,
-		Image:      DEFAULT_IMAGE,
+		Stream:     DEFAULT_STREAM,
 		Fleetlock: FleetlockConfig{
 			Group: DEFAULT_FLEETLOCK_GROUP,
 		},

--- a/pkg/upgraded/config/config_test.go
+++ b/pkg/upgraded/config/config_test.go
@@ -72,7 +72,7 @@ func TestDefaultConfig(t *testing.T) {
 
 	assert.Equal(DEFAULT_LOG_LEVEL, c.LogLevel)
 	assert.Equal(DEFAULT_KUBECONFIG, c.Kubeconfig)
-	assert.Equal(DEFAULT_IMAGE, c.Image)
+	assert.Equal(DEFAULT_STREAM, c.Stream)
 	assert.Equal("", c.Fleetlock.URL)
 	assert.Equal(DEFAULT_FLEETLOCK_GROUP, c.Fleetlock.Group)
 	assert.Equal(DEFAULT_RPM_OSTREE_PATH, c.RPMOStreePath)

--- a/pkg/upgraded/daemon/daemon.go
+++ b/pkg/upgraded/daemon/daemon.go
@@ -28,8 +28,8 @@ type daemon struct {
 	rpmostree *rpmostree.RPMOStreeCMD
 	kubeadm   *kubeadm.KubeadmCMD
 
-	image string
-	node  string
+	stream string
+	node   string
 
 	client kubernetes.Interface
 	ctx    context.Context
@@ -66,8 +66,8 @@ func NewDaemon(cfg *config.Config) (*daemon, error) {
 		return nil, fmt.Errorf("failed to create kubernetes client: %v", err)
 	}
 
-	if cfg.Image == "" {
-		return nil, fmt.Errorf("no image provided for kubernetes updates")
+	if cfg.Stream == "" {
+		return nil, fmt.Errorf("no image stream provided for kubernetes updates")
 	}
 
 	machineID, err := utils.GetMachineID()
@@ -88,7 +88,7 @@ func NewDaemon(cfg *config.Config) (*daemon, error) {
 		rpmostree: rpmOstreeCMD,
 		kubeadm:   kubeadmCMD,
 
-		image:  cfg.Image,
+		stream: cfg.Stream,
 		node:   node,
 		client: kubeClient,
 	}, nil

--- a/pkg/upgraded/daemon/daemon_test.go
+++ b/pkg/upgraded/daemon/daemon_test.go
@@ -24,7 +24,7 @@ func TestNewDaemon(t *testing.T) {
 			Name: "NoNodeFound",
 			CFG: config.Config{
 				Kubeconfig: "testdata/kubeconfig",
-				Image:      config.DEFAULT_IMAGE,
+				Stream:     config.DEFAULT_STREAM,
 				Fleetlock: config.FleetlockConfig{
 					URL:   "https://fleetlock.example.com",
 					Group: config.DEFAULT_FLEETLOCK_GROUP,
@@ -40,7 +40,7 @@ func TestNewDaemon(t *testing.T) {
 			Name: "NoFleetlockUrl",
 			CFG: config.Config{
 				Kubeconfig: "testdata/kubeconfig",
-				Image:      config.DEFAULT_IMAGE,
+				Stream:     config.DEFAULT_STREAM,
 				Fleetlock: config.FleetlockConfig{
 					URL:   "",
 					Group: config.DEFAULT_FLEETLOCK_GROUP,
@@ -56,7 +56,7 @@ func TestNewDaemon(t *testing.T) {
 			Name: "NoRPMOstree",
 			CFG: config.Config{
 				Kubeconfig: "testdata/kubeconfig",
-				Image:      config.DEFAULT_IMAGE,
+				Stream:     config.DEFAULT_STREAM,
 				Fleetlock: config.FleetlockConfig{
 					URL:   "https://fleetlock.example.com",
 					Group: config.DEFAULT_FLEETLOCK_GROUP,
@@ -72,7 +72,7 @@ func TestNewDaemon(t *testing.T) {
 			Name: "NoKubeadm",
 			CFG: config.Config{
 				Kubeconfig: "testdata/kubeconfig",
-				Image:      config.DEFAULT_IMAGE,
+				Stream:     config.DEFAULT_STREAM,
 				Fleetlock: config.FleetlockConfig{
 					URL:   "https://fleetlock.example.com",
 					Group: config.DEFAULT_FLEETLOCK_GROUP,
@@ -88,7 +88,7 @@ func TestNewDaemon(t *testing.T) {
 			Name: "EmptyKubeconfig",
 			CFG: config.Config{
 				Kubeconfig: "",
-				Image:      config.DEFAULT_IMAGE,
+				Stream:     config.DEFAULT_STREAM,
 				Fleetlock: config.FleetlockConfig{
 					URL:   "https://fleetlock.example.com",
 					Group: config.DEFAULT_FLEETLOCK_GROUP,
@@ -104,7 +104,7 @@ func TestNewDaemon(t *testing.T) {
 			Name: "KubeconfigFileNotFound",
 			CFG: config.Config{
 				Kubeconfig: "not-a-file",
-				Image:      config.DEFAULT_IMAGE,
+				Stream:     config.DEFAULT_STREAM,
 				Fleetlock: config.FleetlockConfig{
 					URL:   "https://fleetlock.example.com",
 					Group: config.DEFAULT_FLEETLOCK_GROUP,
@@ -120,7 +120,7 @@ func TestNewDaemon(t *testing.T) {
 			Name: "NoImage",
 			CFG: config.Config{
 				Kubeconfig: "testdata/kubeconfig",
-				Image:      "",
+				Stream:     "",
 				Fleetlock: config.FleetlockConfig{
 					URL:   "https://fleetlock.example.com",
 					Group: config.DEFAULT_FLEETLOCK_GROUP,
@@ -130,7 +130,7 @@ func TestNewDaemon(t *testing.T) {
 				CheckInterval: config.DEFAULT_CHECK_INTERVAL,
 				RetryInterval: config.DEFAULT_RETRY_INTERVAL,
 			},
-			Error: "no image provided for kubernetes updates",
+			Error: "no image stream provided for kubernetes updates",
 		},
 	}
 

--- a/pkg/upgraded/daemon/nodes.go
+++ b/pkg/upgraded/daemon/nodes.go
@@ -89,7 +89,7 @@ func (d *daemon) doNodeUpgrade(node *corev1.Node) error {
 		if err != nil {
 			return fmt.Errorf("failed to update node status: %v", err)
 		}
-		err = d.rpmostree.Rebase(d.image + ":" + version)
+		err = d.rpmostree.Rebase(d.stream + ":" + version)
 		if err != nil {
 			return fmt.Errorf("failed to rebase node: %v", err)
 		}


### PR DESCRIPTION
Rename the image config option to stream, as it does not point to a single image but rather to a repository for multiple image (streams).