### PR TITLE
Makefile: Change build and image command to the respective cmd/ targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,12 @@ SHELL := bash
 REPOSITORY ?= ghcr.io/heathcliff26
 TAG ?= latest
 
-default: build
+default: upgraded upgrade-controller
 
-build:
+upgraded:
 	hack/build.sh upgraded
-	hack/build.sh upgrade-controller
 
-image:
+upgrade-controller:
 	podman build -t $(REPOSITORY)/kube-upgrade-controller:$(TAG) -f cmd/upgrade-controller/Dockerfile .
 
 test:
@@ -44,8 +43,8 @@ controller-gen:
 
 .PHONY: \
 	default \
-	build \
-	image \
+	upgraded \
+	upgrade-controller \
 	test \
 	update-deps \
 	coverprofile \


### PR DESCRIPTION
Instead of building the binary of upgrade-controller with build, or calling image when building it, rename both to upgraded and upgrade-controller respectively.
Additionally make the default action to build both upgraded and upgrade-controller.