### PR TITLE
upgraded: Change config during runtime via node annotations

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,8 +1,9 @@
 package constants
 
 const (
-	baseDomain = "kube-upgrade.heathcliff.eu/"
-	nodePrefix = "node." + baseDomain
+	baseDomain   = "kube-upgrade.heathcliff.eu/"
+	nodePrefix   = "node." + baseDomain
+	configPrefix = "config." + baseDomain
 )
 
 const (
@@ -15,4 +16,12 @@ const (
 	NodeUpgradeStatusRebasing  = "rebasing"
 	NodeUpgradeStatusUpgrading = "upgrading"
 	NodeUpgradeStatusCompleted = "completed"
+)
+
+const (
+	ConfigStream         = configPrefix + "stream"
+	ConfigFleetlockURL   = configPrefix + "fleetlock-url"
+	ConfigFleetlockGroup = configPrefix + "fleetlock-group"
+	ConfigCheckInterval  = configPrefix + "check-interval"
+	ConfigRetryInterval  = configPrefix + "retry-interval"
 )

--- a/pkg/upgraded/config/config.go
+++ b/pkg/upgraded/config/config.go
@@ -107,6 +107,7 @@ func LoadConfig(path string) (*Config, error) {
 
 	f, err := os.ReadFile(p)
 	if os.IsNotExist(err) && path == "" {
+		slog.Info("No config file specified and default file does not exist, falling back to default values.", slog.String("default-path", DEFAULT_CONFIG_PATH))
 		return c, nil
 	} else if err != nil {
 		return nil, err

--- a/pkg/upgraded/daemon/config.go
+++ b/pkg/upgraded/daemon/config.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/heathcliff26/kube-upgrade/pkg/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Update the daemon configuration based on the annotations of the node.
+// Returns on the first error, but will change all configs before that.
+func (d *daemon) UpdateConfigFromNode() error {
+	node, err := d.client.CoreV1().Nodes().Get(d.ctx, d.node, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	return d.UpdateConfigFromAnnotations(node.GetAnnotations())
+}
+
+// Update the daemon configuration from the given annotations.
+// Returns on the first error, but will change all configs before that.
+func (d *daemon) UpdateConfigFromAnnotations(annotations map[string]string) error {
+	for key, value := range annotations {
+		switch key {
+		case constants.ConfigStream:
+			if value == "" {
+				return fmt.Errorf("stream annotation %s is empty", constants.ConfigStream)
+			}
+			if d.stream != value {
+				slog.Info("Updated stream configuration from node annotation", slog.String("annotation", constants.ConfigStream), slog.String("value", value))
+				d.stream = value
+			}
+		case constants.ConfigFleetlockURL:
+			if d.fleetlock.GetURL() != value {
+				slog.Info("Updating fleetlock url from node annotation", slog.String("annotation", constants.ConfigFleetlockURL), slog.String("value", value))
+			} else {
+				continue
+			}
+
+			err := d.fleetlock.SetURL(value)
+			if err != nil {
+				return fmt.Errorf("failed to update fleetlock url to \"%s\": %v", value, err)
+			}
+		case constants.ConfigFleetlockGroup:
+			if d.fleetlock.GetGroup() != value {
+				slog.Info("Updating fleetlock group from node annotation", slog.String("annotation", constants.ConfigFleetlockGroup), slog.String("value", value))
+			} else {
+				continue
+			}
+
+			err := d.fleetlock.SetGroup(value)
+			if err != nil {
+				return fmt.Errorf("failed to update fleetlock group to \"%s\": %v", value, err)
+			}
+		case constants.ConfigCheckInterval:
+			interval, err := time.ParseDuration(value)
+			if err != nil {
+				return fmt.Errorf("failed to parse \"%s\" as duration: %v", value, err)
+			}
+			if d.checkInterval != interval {
+				slog.Info("Updated check interval from node annotation", slog.String("annotation", constants.ConfigStream), slog.String("value", value))
+				d.checkInterval = interval
+			}
+		case constants.ConfigRetryInterval:
+			interval, err := time.ParseDuration(value)
+			if err != nil {
+				return fmt.Errorf("failed to parse \"%s\" as duration: %v", value, err)
+			}
+			if d.retryInterval != interval {
+				slog.Info("Updated retry interval from node annotation", slog.String("annotation", constants.ConfigStream), slog.String("value", value))
+				d.retryInterval = interval
+			}
+		default:
+			continue
+		}
+	}
+
+	if d.fleetlock.GetURL() == "" {
+		return fmt.Errorf("missing fleetlock server url")
+	}
+
+	return nil
+}

--- a/pkg/upgraded/daemon/config_test.go
+++ b/pkg/upgraded/daemon/config_test.go
@@ -1,0 +1,164 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/heathcliff26/kube-upgrade/pkg/constants"
+	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/fleetlock"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestUpdateConfigFromNode(t *testing.T) {
+	assert := assert.New(t)
+
+	client, err := fleetlock.NewClient("https://fleetlock.example.com", "default")
+	if !assert.NoError(err, "Should create a fleetlock client") {
+		t.FailNow()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	d := &daemon{
+		ctx:       ctx,
+		client:    fake.NewSimpleClientset(),
+		node:      "testnode",
+		fleetlock: client,
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: d.node,
+			Annotations: map[string]string{
+				constants.ConfigStream: "registry.example.com/fcos-k8s",
+			},
+		},
+	}
+	_, _ = d.client.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+
+	assert.NoError(d.UpdateConfigFromNode(), "Should succeed")
+	assert.Equal("registry.example.com/fcos-k8s", d.stream, "Should have updated stream")
+
+	d.node = "not-a-node"
+	assert.Error(d.UpdateConfigFromNode(), "Should fail to update from non-existent node")
+}
+
+func TestUpdateConfigFromAnnotations(t *testing.T) {
+	tMatrix := []struct {
+		Name        string
+		Annotations map[string]string
+		Result      struct {
+			Stream         string
+			FleetlockURL   string
+			FleetlockGroup string
+			CheckInterval  time.Duration
+			RetryInterval  time.Duration
+		}
+		Success bool
+	}{
+		{
+			Name: "AllValues",
+			Annotations: map[string]string{
+				constants.ConfigStream:         "registry.example.com/fcos-k8s",
+				constants.ConfigFleetlockURL:   "https://fleetlock.example.com",
+				constants.ConfigFleetlockGroup: "compute",
+				constants.ConfigCheckInterval:  "5m",
+				constants.ConfigRetryInterval:  "2h",
+			},
+			Result: struct {
+				Stream         string
+				FleetlockURL   string
+				FleetlockGroup string
+				CheckInterval  time.Duration
+				RetryInterval  time.Duration
+			}{
+				Stream:         "registry.example.com/fcos-k8s",
+				FleetlockURL:   "https://fleetlock.example.com",
+				FleetlockGroup: "compute",
+				CheckInterval:  5 * time.Minute,
+				RetryInterval:  2 * time.Hour,
+			},
+			Success: true,
+		},
+		{
+			Name: "FleetlockURLOnly",
+			Annotations: map[string]string{
+				constants.ConfigFleetlockURL: "https://fleetlock.example.com",
+			},
+			Result: struct {
+				Stream         string
+				FleetlockURL   string
+				FleetlockGroup string
+				CheckInterval  time.Duration
+				RetryInterval  time.Duration
+			}{
+				FleetlockURL: "https://fleetlock.example.com",
+			},
+			Success: true,
+		},
+		{
+			Name:        "MissingFleetlockURL",
+			Annotations: map[string]string{},
+		},
+		{
+			Name: "EmptyStream",
+			Annotations: map[string]string{
+				constants.ConfigStream: "",
+			},
+		},
+		{
+			Name: "EmptyFleetlockURL",
+			Annotations: map[string]string{
+				constants.ConfigFleetlockURL: "",
+			},
+		},
+		{
+			Name: "EmptyFleetlockGroup",
+			Annotations: map[string]string{
+				constants.ConfigFleetlockGroup: "",
+			},
+		},
+		{
+			Name: "MisformedCheckInterval",
+			Annotations: map[string]string{
+				constants.ConfigCheckInterval: "not-a-duration",
+			},
+		},
+		{
+			Name: "MisformedRetryInterval",
+			Annotations: map[string]string{
+				constants.ConfigRetryInterval: "not-a-duration",
+			},
+		},
+	}
+	for _, tCase := range tMatrix {
+		t.Run(tCase.Name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			client, err := fleetlock.NewEmptyClient()
+			if !assert.NoError(err, "Should create fleetlock client") {
+				t.FailNow()
+			}
+			d := &daemon{
+				fleetlock: client,
+			}
+
+			if tCase.Success {
+				assert.NoError(d.UpdateConfigFromAnnotations(tCase.Annotations), "Should update config from annotations")
+
+				assert.Equal(tCase.Result.Stream, d.stream, "Stream should match")
+				assert.Equal(tCase.Result.FleetlockURL, d.fleetlock.GetURL(), "Fleetlock URL should match")
+				assert.Equal(tCase.Result.FleetlockGroup, d.fleetlock.GetGroup(), "Fleetlock group should match")
+				assert.Equal(tCase.Result.CheckInterval, d.checkInterval, "Check interval should match")
+				assert.Equal(tCase.Result.RetryInterval, d.retryInterval, "Check interval should match")
+			} else {
+				assert.Error(d.UpdateConfigFromAnnotations(tCase.Annotations), "Should fail to update config from annotations")
+			}
+		})
+	}
+}

--- a/pkg/upgraded/daemon/daemon.go
+++ b/pkg/upgraded/daemon/daemon.go
@@ -135,6 +135,11 @@ func (d *daemon) Run() error {
 		return fmt.Errorf("failed to get node status: %v", err)
 	}
 
+	err = d.UpdateConfigFromAnnotations(node.GetAnnotations())
+	if err != nil {
+		return fmt.Errorf("failed to update daemon config from node annotations: %v", err)
+	}
+
 	if !nodeNeedsUpgrade(node) {
 		slog.Debug("Releasing any log that may be held by this machine")
 		d.releaseLock()

--- a/pkg/upgraded/daemon/daemon.go
+++ b/pkg/upgraded/daemon/daemon.go
@@ -40,7 +40,18 @@ type daemon struct {
 
 // Create a new daemon
 func NewDaemon(cfg *config.Config) (*daemon, error) {
-	fleetlockClient, err := fleetlock.NewClient(cfg.Fleetlock.URL, cfg.Fleetlock.Group)
+	var err error
+	var fleetlockClient *fleetlock.FleetlockClient
+	if cfg.Fleetlock.URL != "" {
+		slog.Debug("Creating fleetlock client with url", slog.String("url", cfg.Fleetlock.URL))
+		fleetlockClient, err = fleetlock.NewClient(cfg.Fleetlock.URL, cfg.Fleetlock.Group)
+	} else {
+		slog.Debug("Creating fleetlock client without url")
+		fleetlockClient, err = fleetlock.NewEmptyClient()
+		if err != nil && cfg.Fleetlock.Group != "" {
+			err = fleetlockClient.SetGroup(cfg.Fleetlock.Group)
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create fleetlock client: %v", err)
 	}

--- a/pkg/upgraded/daemon/daemon_test.go
+++ b/pkg/upgraded/daemon/daemon_test.go
@@ -50,7 +50,8 @@ func TestNewDaemon(t *testing.T) {
 				CheckInterval: config.DEFAULT_CHECK_INTERVAL,
 				RetryInterval: config.DEFAULT_RETRY_INTERVAL,
 			},
-			Error: "failed to create fleetlock client:",
+			// This means it should create an empty fleetlock client instead of failling
+			Error: "failed to get kubernetes node name for host",
 		},
 		{
 			Name: "NoRPMOstree",

--- a/pkg/upgraded/daemon/nodes.go
+++ b/pkg/upgraded/daemon/nodes.go
@@ -75,10 +75,15 @@ func (d *daemon) doNodeUpgrade(node *corev1.Node) error {
 	}
 	defer d.upgrade.Unlock()
 
+	err := d.UpdateConfigFromAnnotations(node.GetAnnotations())
+	if err != nil {
+		return fmt.Errorf("failed to update daemon config from node annotations: %v", err)
+	}
+
 	version := node.Annotations[constants.NodeKubernetesVersion]
 	slog.Info("Attempting node upgrade to new kubernetes version", slog.String("node", node.GetName()), slog.String("version", version))
 
-	err := d.fleetlock.Lock()
+	err = d.fleetlock.Lock()
 	if err != nil {
 		return fmt.Errorf("failed to aquire lock: %v", err)
 	}

--- a/pkg/upgraded/daemon/stream.go
+++ b/pkg/upgraded/daemon/stream.go
@@ -53,7 +53,12 @@ func (d *daemon) doUpgrade() error {
 	}
 	defer d.upgrade.Unlock()
 
-	err := d.fleetlock.Lock()
+	err := d.UpdateConfigFromNode()
+	if err != nil {
+		return fmt.Errorf("failed to update daemon config from node annotations: %v", err)
+	}
+
+	err = d.fleetlock.Lock()
 	if err != nil {
 		return fmt.Errorf("failed to aquire lock: %v", err)
 	}

--- a/pkg/upgraded/daemon/stream_test.go
+++ b/pkg/upgraded/daemon/stream_test.go
@@ -1,14 +1,37 @@
 package daemon
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
+	"github.com/heathcliff26/kube-upgrade/pkg/upgraded/fleetlock"
 	rpmostree "github.com/heathcliff26/kube-upgrade/pkg/upgraded/rpm-ostree"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestDoUpgrade(t *testing.T) {
+	fakeDaemon := func(fleetlock *fleetlock.FleetlockClient, rpmostree *rpmostree.RPMOStreeCMD) *daemon {
+		d := &daemon{
+			fleetlock: fleetlock,
+			rpmostree: rpmostree,
+			node:      "testnode",
+			client:    fake.NewSimpleClientset(),
+		}
+
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: d.node,
+			},
+		}
+		_, _ = d.client.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+
+		return d
+	}
+
 	t.Run("LockAlreadyReserved", func(t *testing.T) {
 		assert := assert.New(t)
 
@@ -21,10 +44,7 @@ func TestDoUpgrade(t *testing.T) {
 			t.FailNow()
 		}
 
-		d := &daemon{
-			fleetlock: client,
-			rpmostree: rpmOstreeCMD,
-		}
+		d := fakeDaemon(client, rpmOstreeCMD)
 
 		err = d.doUpgrade()
 
@@ -42,10 +62,7 @@ func TestDoUpgrade(t *testing.T) {
 			t.FailNow()
 		}
 
-		d := &daemon{
-			fleetlock: client,
-			rpmostree: rpmOstreeCMD,
-		}
+		d := fakeDaemon(client, rpmOstreeCMD)
 
 		err = d.doUpgrade()
 
@@ -72,10 +89,7 @@ func TestDoUpgrade(t *testing.T) {
 			t.FailNow()
 		}
 
-		d := &daemon{
-			fleetlock: client,
-			rpmostree: rpmOstreeCMD,
-		}
+		d := fakeDaemon(client, rpmOstreeCMD)
 
 		err = d.doUpgrade()
 

--- a/pkg/upgraded/fleetlock/client_test.go
+++ b/pkg/upgraded/fleetlock/client_test.go
@@ -53,6 +53,20 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewEmptyClient(t *testing.T) {
+	assert := assert.New(t)
+
+	res, err := NewEmptyClient()
+
+	if !assert.NoError(err, "Should succeed") || !assert.NotNil(res, "Should return a client") {
+		t.FailNow()
+	}
+
+	assert.Empty(res.url, "Client should not have the url set")
+	assert.Empty(res.group, "Client should not have the group set")
+	assert.NotEmpty(res.appID, "Client should have the appID set")
+}
+
 func TestLock(t *testing.T) {
 	assert := assert.New(t)
 
@@ -83,6 +97,38 @@ func TestRelease(t *testing.T) {
 
 	err = c2.Release()
 	assert.Error(err, "Should not succeed")
+}
+
+func TestGetAndSet(t *testing.T) {
+	t.Run("URL", func(t *testing.T) {
+		assert := assert.New(t)
+
+		var c *FleetlockClient
+		assert.Empty(c.GetURL(), "Should not panic when reading URL from nil pointer")
+
+		c = &FleetlockClient{}
+
+		assert.NoError(c.SetURL("https://fleetlock.example.com"), "Should set URL without error")
+		assert.Equal("https://fleetlock.example.com", c.GetURL(), "URL should match")
+
+		assert.NoError(c.SetURL("https://fleetlock.example.com/"), "Should set URL without trailing slash")
+		assert.Equal("https://fleetlock.example.com", c.GetURL(), "URL should not have trailing /")
+
+		assert.Error(c.SetURL(""), "Should not accept empty URL")
+	})
+	t.Run("Group", func(t *testing.T) {
+		assert := assert.New(t)
+
+		var c *FleetlockClient
+		assert.Empty(c.GetGroup(), "Should not panic when reading group from nil pointer")
+
+		c = &FleetlockClient{}
+
+		assert.NoError(c.SetGroup("default"), "Should set group without error")
+		assert.Equal("default", c.GetGroup(), "group should match")
+
+		assert.Error(c.SetGroup(""), "Should not accept empty group")
+	})
 }
 
 func NewFakeServer(t *testing.T, statusCode int, path string) (*FleetlockClient, *httptest.Server) {


### PR DESCRIPTION
Add the option to change a subset of configuration options during runtime of
the daemon by setting node annotations.
With the option of configuring the daemon via node annotations, it is no
longer necessary to fail when no config file is provided.