### PR TITLE
api: Rename package imports to api

### DIFF
--- a/pkg/upgrade-controller/controller/controller_test.go
+++ b/pkg/upgrade-controller/controller/controller_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha1"
+	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha1"
 	"github.com/heathcliff26/kube-upgrade/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -35,7 +35,7 @@ func TestNewController(t *testing.T) {
 func TestReconcile(t *testing.T) {
 	tMatrix := []struct {
 		Name                                                                             string
-		Plan                                                                             v1alpha1.KubeUpgradePlan
+		Plan                                                                             api.KubeUpgradePlan
 		AnnotationsControl, AnnotationsCompute, AnnotationsInfra                         map[string]string
 		ExpectedSummary                                                                  string
 		ExpectedGroupStatus                                                              map[string]string
@@ -43,13 +43,13 @@ func TestReconcile(t *testing.T) {
 	}{
 		{
 			Name: "InitialReconcile",
-			Plan: v1alpha1.KubeUpgradePlan{
+			Plan: api.KubeUpgradePlan{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "upgrade-plan",
 				},
-				Spec: v1alpha1.KubeUpgradeSpec{
+				Spec: api.KubeUpgradeSpec{
 					KubernetesVersion: "v1.31.0",
-					Groups: map[string]v1alpha1.KubeUpgradePlanGroup{
+					Groups: map[string]api.KubeUpgradePlanGroup{
 						"control": {
 							Labels: map[string]string{
 								groupLabel: groupControl,
@@ -70,11 +70,11 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSummary: v1alpha1.PlanStatusProgressing,
+			ExpectedSummary: api.PlanStatusProgressing,
 			ExpectedGroupStatus: map[string]string{
-				groupControl: v1alpha1.PlanStatusProgressing,
-				groupCompute: v1alpha1.PlanStatusWaiting,
-				groupInfra:   v1alpha1.PlanStatusWaiting,
+				groupControl: api.PlanStatusProgressing,
+				groupCompute: api.PlanStatusWaiting,
+				groupInfra:   api.PlanStatusWaiting,
 			},
 			ExpectedAnnotationsControl: map[string]string{
 				constants.NodeKubernetesVersion: "v1.31.0",
@@ -83,13 +83,13 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			Name: "2ndReconcile",
-			Plan: v1alpha1.KubeUpgradePlan{
+			Plan: api.KubeUpgradePlan{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "upgrade-plan",
 				},
-				Spec: v1alpha1.KubeUpgradeSpec{
+				Spec: api.KubeUpgradeSpec{
 					KubernetesVersion: "v1.31.0",
-					Groups: map[string]v1alpha1.KubeUpgradePlanGroup{
+					Groups: map[string]api.KubeUpgradePlanGroup{
 						"control": {
 							Labels: map[string]string{
 								groupLabel: groupControl,
@@ -109,12 +109,12 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.KubeUpgradeStatus{
-					Summary: v1alpha1.PlanStatusProgressing,
+				Status: api.KubeUpgradeStatus{
+					Summary: api.PlanStatusProgressing,
 					Groups: map[string]string{
-						groupControl: v1alpha1.PlanStatusProgressing,
-						groupCompute: v1alpha1.PlanStatusWaiting,
-						groupInfra:   v1alpha1.PlanStatusWaiting,
+						groupControl: api.PlanStatusProgressing,
+						groupCompute: api.PlanStatusWaiting,
+						groupInfra:   api.PlanStatusWaiting,
 					},
 				},
 			},
@@ -122,11 +122,11 @@ func TestReconcile(t *testing.T) {
 				constants.NodeKubernetesVersion: "v1.31.0",
 				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
-			ExpectedSummary: v1alpha1.PlanStatusProgressing,
+			ExpectedSummary: api.PlanStatusProgressing,
 			ExpectedGroupStatus: map[string]string{
-				groupControl: v1alpha1.PlanStatusComplete,
-				groupCompute: v1alpha1.PlanStatusWaiting,
-				groupInfra:   v1alpha1.PlanStatusProgressing,
+				groupControl: api.PlanStatusComplete,
+				groupCompute: api.PlanStatusWaiting,
+				groupInfra:   api.PlanStatusProgressing,
 			},
 			ExpectedAnnotationsControl: map[string]string{
 				constants.NodeKubernetesVersion: "v1.31.0",
@@ -139,13 +139,13 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			Name: "3rdReconcile",
-			Plan: v1alpha1.KubeUpgradePlan{
+			Plan: api.KubeUpgradePlan{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "upgrade-plan",
 				},
-				Spec: v1alpha1.KubeUpgradeSpec{
+				Spec: api.KubeUpgradeSpec{
 					KubernetesVersion: "v1.31.0",
-					Groups: map[string]v1alpha1.KubeUpgradePlanGroup{
+					Groups: map[string]api.KubeUpgradePlanGroup{
 						"control": {
 							Labels: map[string]string{
 								groupLabel: groupControl,
@@ -165,12 +165,12 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.KubeUpgradeStatus{
-					Summary: v1alpha1.PlanStatusProgressing,
+				Status: api.KubeUpgradeStatus{
+					Summary: api.PlanStatusProgressing,
 					Groups: map[string]string{
-						groupControl: v1alpha1.PlanStatusComplete,
-						groupCompute: v1alpha1.PlanStatusWaiting,
-						groupInfra:   v1alpha1.PlanStatusProgressing,
+						groupControl: api.PlanStatusComplete,
+						groupCompute: api.PlanStatusWaiting,
+						groupInfra:   api.PlanStatusProgressing,
 					},
 				},
 			},
@@ -182,11 +182,11 @@ func TestReconcile(t *testing.T) {
 				constants.NodeKubernetesVersion: "v1.31.0",
 				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
-			ExpectedSummary: v1alpha1.PlanStatusProgressing,
+			ExpectedSummary: api.PlanStatusProgressing,
 			ExpectedGroupStatus: map[string]string{
-				groupControl: v1alpha1.PlanStatusComplete,
-				groupCompute: v1alpha1.PlanStatusProgressing,
-				groupInfra:   v1alpha1.PlanStatusComplete,
+				groupControl: api.PlanStatusComplete,
+				groupCompute: api.PlanStatusProgressing,
+				groupInfra:   api.PlanStatusComplete,
 			},
 			ExpectedAnnotationsControl: map[string]string{
 				constants.NodeKubernetesVersion: "v1.31.0",
@@ -203,13 +203,13 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			Name: "4thReconcile",
-			Plan: v1alpha1.KubeUpgradePlan{
+			Plan: api.KubeUpgradePlan{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "upgrade-plan",
 				},
-				Spec: v1alpha1.KubeUpgradeSpec{
+				Spec: api.KubeUpgradeSpec{
 					KubernetesVersion: "v1.31.0",
-					Groups: map[string]v1alpha1.KubeUpgradePlanGroup{
+					Groups: map[string]api.KubeUpgradePlanGroup{
 						"control": {
 							Labels: map[string]string{
 								groupLabel: groupControl,
@@ -229,12 +229,12 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.KubeUpgradeStatus{
-					Summary: v1alpha1.PlanStatusProgressing,
+				Status: api.KubeUpgradeStatus{
+					Summary: api.PlanStatusProgressing,
 					Groups: map[string]string{
-						groupControl: v1alpha1.PlanStatusComplete,
-						groupCompute: v1alpha1.PlanStatusProgressing,
-						groupInfra:   v1alpha1.PlanStatusComplete,
+						groupControl: api.PlanStatusComplete,
+						groupCompute: api.PlanStatusProgressing,
+						groupInfra:   api.PlanStatusComplete,
 					},
 				},
 			},
@@ -250,11 +250,11 @@ func TestReconcile(t *testing.T) {
 				constants.NodeKubernetesVersion: "v1.31.0",
 				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
-			ExpectedSummary: v1alpha1.PlanStatusComplete,
+			ExpectedSummary: api.PlanStatusComplete,
 			ExpectedGroupStatus: map[string]string{
-				groupControl: v1alpha1.PlanStatusComplete,
-				groupCompute: v1alpha1.PlanStatusComplete,
-				groupInfra:   v1alpha1.PlanStatusComplete,
+				groupControl: api.PlanStatusComplete,
+				groupCompute: api.PlanStatusComplete,
+				groupInfra:   api.PlanStatusComplete,
 			},
 			ExpectedAnnotationsControl: map[string]string{
 				constants.NodeKubernetesVersion: "v1.31.0",
@@ -271,13 +271,13 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			Name: "NewUpdate",
-			Plan: v1alpha1.KubeUpgradePlan{
+			Plan: api.KubeUpgradePlan{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "upgrade-plan",
 				},
-				Spec: v1alpha1.KubeUpgradeSpec{
+				Spec: api.KubeUpgradeSpec{
 					KubernetesVersion: "v1.31.0",
-					Groups: map[string]v1alpha1.KubeUpgradePlanGroup{
+					Groups: map[string]api.KubeUpgradePlanGroup{
 						"control": {
 							Labels: map[string]string{
 								groupLabel: groupControl,
@@ -291,11 +291,11 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.KubeUpgradeStatus{
-					Summary: v1alpha1.PlanStatusComplete,
+				Status: api.KubeUpgradeStatus{
+					Summary: api.PlanStatusComplete,
 					Groups: map[string]string{
-						groupControl: v1alpha1.PlanStatusComplete,
-						groupCompute: v1alpha1.PlanStatusComplete,
+						groupControl: api.PlanStatusComplete,
+						groupCompute: api.PlanStatusComplete,
 					},
 				},
 			},
@@ -307,10 +307,10 @@ func TestReconcile(t *testing.T) {
 				constants.NodeKubernetesVersion: "v1.30.4",
 				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
-			ExpectedSummary: v1alpha1.PlanStatusProgressing,
+			ExpectedSummary: api.PlanStatusProgressing,
 			ExpectedGroupStatus: map[string]string{
-				groupControl: v1alpha1.PlanStatusProgressing,
-				groupCompute: v1alpha1.PlanStatusWaiting,
+				groupControl: api.PlanStatusProgressing,
+				groupCompute: api.PlanStatusWaiting,
 			},
 			ExpectedAnnotationsControl: map[string]string{
 				constants.NodeKubernetesVersion: "v1.31.0",
@@ -323,13 +323,13 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			Name: "Update2ndReconcile",
-			Plan: v1alpha1.KubeUpgradePlan{
+			Plan: api.KubeUpgradePlan{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "upgrade-plan",
 				},
-				Spec: v1alpha1.KubeUpgradeSpec{
+				Spec: api.KubeUpgradeSpec{
 					KubernetesVersion: "v1.31.0",
-					Groups: map[string]v1alpha1.KubeUpgradePlanGroup{
+					Groups: map[string]api.KubeUpgradePlanGroup{
 						"control": {
 							Labels: map[string]string{
 								groupLabel: groupControl,
@@ -343,11 +343,11 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.KubeUpgradeStatus{
-					Summary: v1alpha1.PlanStatusProgressing,
+				Status: api.KubeUpgradeStatus{
+					Summary: api.PlanStatusProgressing,
 					Groups: map[string]string{
-						groupControl: v1alpha1.PlanStatusProgressing,
-						groupCompute: v1alpha1.PlanStatusWaiting,
+						groupControl: api.PlanStatusProgressing,
+						groupCompute: api.PlanStatusWaiting,
 					},
 				},
 			},
@@ -359,10 +359,10 @@ func TestReconcile(t *testing.T) {
 				constants.NodeKubernetesVersion: "v1.30.4",
 				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
-			ExpectedSummary: v1alpha1.PlanStatusProgressing,
+			ExpectedSummary: api.PlanStatusProgressing,
 			ExpectedGroupStatus: map[string]string{
-				groupControl: v1alpha1.PlanStatusComplete,
-				groupCompute: v1alpha1.PlanStatusProgressing,
+				groupControl: api.PlanStatusComplete,
+				groupCompute: api.PlanStatusProgressing,
 			},
 			ExpectedAnnotationsControl: map[string]string{
 				constants.NodeKubernetesVersion: "v1.31.0",
@@ -375,13 +375,13 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			Name: "Update3rdReconcile",
-			Plan: v1alpha1.KubeUpgradePlan{
+			Plan: api.KubeUpgradePlan{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "upgrade-plan",
 				},
-				Spec: v1alpha1.KubeUpgradeSpec{
+				Spec: api.KubeUpgradeSpec{
 					KubernetesVersion: "v1.31.0",
-					Groups: map[string]v1alpha1.KubeUpgradePlanGroup{
+					Groups: map[string]api.KubeUpgradePlanGroup{
 						"control": {
 							Labels: map[string]string{
 								groupLabel: groupControl,
@@ -395,11 +395,11 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.KubeUpgradeStatus{
-					Summary: v1alpha1.PlanStatusProgressing,
+				Status: api.KubeUpgradeStatus{
+					Summary: api.PlanStatusProgressing,
 					Groups: map[string]string{
-						groupControl: v1alpha1.PlanStatusComplete,
-						groupCompute: v1alpha1.PlanStatusProgressing,
+						groupControl: api.PlanStatusComplete,
+						groupCompute: api.PlanStatusProgressing,
 					},
 				},
 			},
@@ -411,10 +411,10 @@ func TestReconcile(t *testing.T) {
 				constants.NodeKubernetesVersion: "v1.31.0",
 				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
-			ExpectedSummary: v1alpha1.PlanStatusComplete,
+			ExpectedSummary: api.PlanStatusComplete,
 			ExpectedGroupStatus: map[string]string{
-				groupControl: v1alpha1.PlanStatusComplete,
-				groupCompute: v1alpha1.PlanStatusComplete,
+				groupControl: api.PlanStatusComplete,
+				groupCompute: api.PlanStatusComplete,
 			},
 			ExpectedAnnotationsControl: map[string]string{
 				constants.NodeKubernetesVersion: "v1.31.0",

--- a/pkg/upgrade-controller/controller/utils.go
+++ b/pkg/upgrade-controller/controller/utils.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha1"
+	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha1"
 )
 
 var serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
@@ -39,7 +39,7 @@ func Pointer[T any](v T) *T {
 // Check if the given group needs to wait on another one
 func groupWaitForDependency(deps []string, status map[string]string) bool {
 	for _, d := range deps {
-		if status[d] != v1alpha1.PlanStatusComplete {
+		if status[d] != api.PlanStatusComplete {
 			return true
 		}
 	}
@@ -49,7 +49,7 @@ func groupWaitForDependency(deps []string, status map[string]string) bool {
 // Return the status summary from the given input
 func createStatusSummary(status map[string]string) string {
 	if len(status) == 0 {
-		return v1alpha1.PlanStatusUnknown
+		return api.PlanStatusUnknown
 	}
 	waiting := false
 	unknown := false
@@ -57,10 +57,10 @@ func createStatusSummary(status map[string]string) string {
 
 	for _, v := range status {
 		switch v {
-		case v1alpha1.PlanStatusComplete:
-		case v1alpha1.PlanStatusProgressing:
+		case api.PlanStatusComplete:
+		case api.PlanStatusProgressing:
 			progressing = true
-		case v1alpha1.PlanStatusWaiting:
+		case api.PlanStatusWaiting:
 			waiting = true
 		default:
 			unknown = true
@@ -68,12 +68,12 @@ func createStatusSummary(status map[string]string) string {
 	}
 
 	if unknown {
-		return v1alpha1.PlanStatusUnknown
+		return api.PlanStatusUnknown
 	} else if progressing {
-		return v1alpha1.PlanStatusProgressing
+		return api.PlanStatusProgressing
 	} else if waiting {
-		return v1alpha1.PlanStatusWaiting
+		return api.PlanStatusWaiting
 	} else {
-		return v1alpha1.PlanStatusComplete
+		return api.PlanStatusComplete
 	}
 }

--- a/pkg/upgrade-controller/controller/utils_test.go
+++ b/pkg/upgrade-controller/controller/utils_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha1"
+	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,9 +88,9 @@ func TestGroupWaitForDependency(t *testing.T) {
 			Name: "NoDependencies",
 			Deps: nil,
 			Status: map[string]string{
-				"foo":    v1alpha1.PlanStatusComplete,
-				"bar":    v1alpha1.PlanStatusProgressing,
-				"foobar": v1alpha1.PlanStatusComplete,
+				"foo":    api.PlanStatusComplete,
+				"bar":    api.PlanStatusProgressing,
+				"foobar": api.PlanStatusComplete,
 			},
 			Result: false,
 		},
@@ -98,9 +98,9 @@ func TestGroupWaitForDependency(t *testing.T) {
 			Name: "DependenciesComplete",
 			Deps: []string{"foo", "foobar"},
 			Status: map[string]string{
-				"foo":    v1alpha1.PlanStatusComplete,
-				"bar":    v1alpha1.PlanStatusProgressing,
-				"foobar": v1alpha1.PlanStatusComplete,
+				"foo":    api.PlanStatusComplete,
+				"bar":    api.PlanStatusProgressing,
+				"foobar": api.PlanStatusComplete,
 			},
 			Result: false,
 		},
@@ -108,9 +108,9 @@ func TestGroupWaitForDependency(t *testing.T) {
 			Name: "Wait",
 			Deps: []string{"foo", "foobar", "bar"},
 			Status: map[string]string{
-				"foo":    v1alpha1.PlanStatusComplete,
-				"bar":    v1alpha1.PlanStatusProgressing,
-				"foobar": v1alpha1.PlanStatusComplete,
+				"foo":    api.PlanStatusComplete,
+				"bar":    api.PlanStatusProgressing,
+				"foobar": api.PlanStatusComplete,
 			},
 			Result: true,
 		},
@@ -130,39 +130,39 @@ func TestCreateStatusSummary(t *testing.T) {
 	}{
 		{
 			Status: map[string]string{
-				"foo":    v1alpha1.PlanStatusComplete,
-				"bar":    v1alpha1.PlanStatusComplete,
-				"foobar": v1alpha1.PlanStatusComplete,
+				"foo":    api.PlanStatusComplete,
+				"bar":    api.PlanStatusComplete,
+				"foobar": api.PlanStatusComplete,
 			},
-			Result: v1alpha1.PlanStatusComplete,
+			Result: api.PlanStatusComplete,
 		},
 		{
 			Status: map[string]string{
-				"foo":    v1alpha1.PlanStatusComplete,
-				"bar":    v1alpha1.PlanStatusWaiting,
-				"foobar": v1alpha1.PlanStatusComplete,
+				"foo":    api.PlanStatusComplete,
+				"bar":    api.PlanStatusWaiting,
+				"foobar": api.PlanStatusComplete,
 			},
-			Result: v1alpha1.PlanStatusWaiting,
+			Result: api.PlanStatusWaiting,
 		},
 		{
 			Status: map[string]string{
-				"foo":    v1alpha1.PlanStatusComplete,
-				"bar":    v1alpha1.PlanStatusProgressing,
-				"foobar": v1alpha1.PlanStatusComplete,
+				"foo":    api.PlanStatusComplete,
+				"bar":    api.PlanStatusProgressing,
+				"foobar": api.PlanStatusComplete,
 			},
-			Result: v1alpha1.PlanStatusProgressing,
+			Result: api.PlanStatusProgressing,
 		},
 		{
 			Status: map[string]string{
-				"foo":    v1alpha1.PlanStatusUnknown,
-				"bar":    v1alpha1.PlanStatusProgressing,
-				"foobar": v1alpha1.PlanStatusComplete,
+				"foo":    api.PlanStatusUnknown,
+				"bar":    api.PlanStatusProgressing,
+				"foobar": api.PlanStatusComplete,
 			},
-			Result: v1alpha1.PlanStatusUnknown,
+			Result: api.PlanStatusUnknown,
 		},
 		{
 			Status: map[string]string{},
-			Result: v1alpha1.PlanStatusUnknown,
+			Result: api.PlanStatusUnknown,
 		},
 	}
 


### PR DESCRIPTION
To allow for better version upgrade, rename all imports for v1alpha1 to api.