### PR TITLE
api: Fix wrong type for intervals in upgraded config

### DIFF
--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -79,8 +79,8 @@ spec:
                         check-interval:
                           description: The interval between regular checks
                           example: 3h;24h;30m
-                          format: int64
-                          type: integer
+                          format: duration
+                          type: string
                         fleetlock-group:
                           description: The group to use for fleetlock
                           example: control-plane;compute
@@ -95,8 +95,8 @@ spec:
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
-                          format: int64
-                          type: integer
+                          format: duration
+                          type: string
                         stream:
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
@@ -125,8 +125,8 @@ spec:
                   check-interval:
                     description: The interval between regular checks
                     example: 3h;24h;30m
-                    format: int64
-                    type: integer
+                    format: duration
+                    type: string
                   fleetlock-group:
                     description: The group to use for fleetlock
                     example: control-plane;compute
@@ -140,8 +140,8 @@ spec:
                   retry-interval:
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
-                    format: int64
-                    type: integer
+                    format: duration
+                    type: string
                   stream:
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s

--- a/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
+++ b/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
@@ -74,8 +74,8 @@ spec:
                         check-interval:
                           description: The interval between regular checks
                           example: 3h;24h;30m
-                          format: int64
-                          type: integer
+                          format: duration
+                          type: string
                         fleetlock-group:
                           description: The group to use for fleetlock
                           example: control-plane;compute
@@ -90,8 +90,8 @@ spec:
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
-                          format: int64
-                          type: integer
+                          format: duration
+                          type: string
                         stream:
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
@@ -120,8 +120,8 @@ spec:
                   check-interval:
                     description: The interval between regular checks
                     example: 3h;24h;30m
-                    format: int64
-                    type: integer
+                    format: duration
+                    type: string
                   fleetlock-group:
                     description: The group to use for fleetlock
                     example: control-plane;compute
@@ -135,8 +135,8 @@ spec:
                   retry-interval:
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
-                    format: int64
-                    type: integer
+                    format: duration
+                    type: string
                   stream:
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s

--- a/pkg/apis/kubeupgrade/v1alpha1/defaults.go
+++ b/pkg/apis/kubeupgrade/v1alpha1/defaults.go
@@ -1,7 +1,5 @@
 package v1alpha1
 
-import "time"
-
 func SetObjectDefaults_KubeUpgradeSpec(spec *KubeUpgradeSpec) {
 	if spec.Groups == nil {
 		spec.Groups = make(map[string]KubeUpgradePlanGroup)
@@ -27,11 +25,11 @@ func SetObjectDefaults_UpgradedConfig(cfg *UpgradedConfig) {
 	if cfg.FleetlockGroup == "" {
 		cfg.FleetlockGroup = "default"
 	}
-	if cfg.CheckInterval == 0 {
-		cfg.CheckInterval = time.Hour * 3
+	if cfg.CheckInterval == "" {
+		cfg.CheckInterval = "3h"
 	}
-	if cfg.RetryInterval == 0 {
-		cfg.RetryInterval = time.Minute * 5
+	if cfg.RetryInterval == "" {
+		cfg.RetryInterval = "5m"
 	}
 }
 

--- a/pkg/apis/kubeupgrade/v1alpha1/types.go
+++ b/pkg/apis/kubeupgrade/v1alpha1/types.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -101,15 +99,17 @@ type UpgradedConfig struct {
 
 	// The interval between regular checks
 	// +optional
+	// +kubebuilder:validation:Format=duration
 	// +default="3h"
 	// +kubebuilder:example="3h;24h;30m"
-	CheckInterval time.Duration `json:"check-interval,omitempty"`
+	CheckInterval string `json:"check-interval,omitempty"`
 
 	// The interval between retries when an operation fails
 	// +optional
+	// +kubebuilder:validation:Format=duration
 	// +default="5m"
 	// +kubebuilder:example="5m;1m;30s"
-	RetryInterval time.Duration `json:"retry-interval,omitempty"`
+	RetryInterval string `json:"retry-interval,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/client/applyconfiguration/kubeupgrade/v1alpha1/upgradedconfig.go
+++ b/pkg/client/applyconfiguration/kubeupgrade/v1alpha1/upgradedconfig.go
@@ -2,18 +2,14 @@
 
 package v1alpha1
 
-import (
-	time "time"
-)
-
 // UpgradedConfigApplyConfiguration represents a declarative configuration of the UpgradedConfig type for use
 // with apply.
 type UpgradedConfigApplyConfiguration struct {
-	Stream         *string        `json:"stream,omitempty"`
-	FleetlockURL   *string        `json:"fleetlock-url,omitempty"`
-	FleetlockGroup *string        `json:"fleetlock-group,omitempty"`
-	CheckInterval  *time.Duration `json:"check-interval,omitempty"`
-	RetryInterval  *time.Duration `json:"retry-interval,omitempty"`
+	Stream         *string `json:"stream,omitempty"`
+	FleetlockURL   *string `json:"fleetlock-url,omitempty"`
+	FleetlockGroup *string `json:"fleetlock-group,omitempty"`
+	CheckInterval  *string `json:"check-interval,omitempty"`
+	RetryInterval  *string `json:"retry-interval,omitempty"`
 }
 
 // UpgradedConfigApplyConfiguration constructs a declarative configuration of the UpgradedConfig type for use with
@@ -49,7 +45,7 @@ func (b *UpgradedConfigApplyConfiguration) WithFleetlockGroup(value string) *Upg
 // WithCheckInterval sets the CheckInterval field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the CheckInterval field is set to the value of the last call.
-func (b *UpgradedConfigApplyConfiguration) WithCheckInterval(value time.Duration) *UpgradedConfigApplyConfiguration {
+func (b *UpgradedConfigApplyConfiguration) WithCheckInterval(value string) *UpgradedConfigApplyConfiguration {
 	b.CheckInterval = &value
 	return b
 }
@@ -57,7 +53,7 @@ func (b *UpgradedConfigApplyConfiguration) WithCheckInterval(value time.Duration
 // WithRetryInterval sets the RetryInterval field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the RetryInterval field is set to the value of the last call.
-func (b *UpgradedConfigApplyConfiguration) WithRetryInterval(value time.Duration) *UpgradedConfigApplyConfiguration {
+func (b *UpgradedConfigApplyConfiguration) WithRetryInterval(value string) *UpgradedConfigApplyConfiguration {
 	b.RetryInterval = &value
 	return b
 }

--- a/pkg/upgrade-controller/controller/config.go
+++ b/pkg/upgrade-controller/controller/config.go
@@ -30,10 +30,10 @@ func combineConfig(global, group *api.UpgradedConfig) map[string]string {
 	if group.FleetlockGroup != "" {
 		cfg.FleetlockGroup = group.FleetlockGroup
 	}
-	if group.CheckInterval != 0 {
+	if group.CheckInterval != "" {
 		cfg.CheckInterval = group.CheckInterval
 	}
-	if group.RetryInterval != 0 {
+	if group.RetryInterval != "" {
 		cfg.RetryInterval = group.RetryInterval
 	}
 
@@ -56,11 +56,11 @@ func createConfigAnnotations(cfg *api.UpgradedConfig) map[string]string {
 	if cfg.FleetlockGroup != "" {
 		res[constants.ConfigFleetlockGroup] = cfg.FleetlockGroup
 	}
-	if cfg.CheckInterval != 0 {
-		res[constants.ConfigCheckInterval] = cfg.CheckInterval.String()
+	if cfg.CheckInterval != "" {
+		res[constants.ConfigCheckInterval] = cfg.CheckInterval
 	}
-	if cfg.RetryInterval != 0 {
-		res[constants.ConfigRetryInterval] = cfg.RetryInterval.String()
+	if cfg.RetryInterval != "" {
+		res[constants.ConfigRetryInterval] = cfg.RetryInterval
 	}
 
 	return res

--- a/pkg/upgrade-controller/controller/config_test.go
+++ b/pkg/upgrade-controller/controller/config_test.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"testing"
-	"time"
 
 	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha1"
 	"github.com/heathcliff26/kube-upgrade/pkg/constants"
@@ -21,22 +20,22 @@ func TestCombineConfig(t *testing.T) {
 				Stream:         "registry.example.org/test-stream",
 				FleetlockURL:   "https://fleetlock.example.org",
 				FleetlockGroup: "not-default",
-				CheckInterval:  time.Minute * 10,
-				RetryInterval:  time.Minute * 15,
+				CheckInterval:  "10m",
+				RetryInterval:  "15m",
 			},
 			Group: &api.UpgradedConfig{
 				Stream:         "registry.example.com/test-stream",
 				FleetlockURL:   "https://fleetlock.example.com",
 				FleetlockGroup: "default",
-				CheckInterval:  time.Minute * 2,
-				RetryInterval:  time.Minute * 3,
+				CheckInterval:  "2m",
+				RetryInterval:  "3m",
 			},
 			Result: map[string]string{
 				constants.ConfigStream:         "registry.example.com/test-stream",
 				constants.ConfigFleetlockURL:   "https://fleetlock.example.com",
 				constants.ConfigFleetlockGroup: "default",
-				constants.ConfigCheckInterval:  "2m0s",
-				constants.ConfigRetryInterval:  "3m0s",
+				constants.ConfigCheckInterval:  "2m",
+				constants.ConfigRetryInterval:  "3m",
 			},
 		},
 		{
@@ -45,20 +44,20 @@ func TestCombineConfig(t *testing.T) {
 				Stream:         "registry.example.org/test-stream",
 				FleetlockURL:   "https://fleetlock.example.org",
 				FleetlockGroup: "not-default",
-				CheckInterval:  time.Minute * 10,
-				RetryInterval:  time.Minute * 15,
+				CheckInterval:  "10m",
+				RetryInterval:  "15m",
 			},
 			Group: &api.UpgradedConfig{
 				FleetlockGroup: "default",
-				CheckInterval:  time.Minute * 2,
-				RetryInterval:  time.Minute * 3,
+				CheckInterval:  "2m",
+				RetryInterval:  "3m",
 			},
 			Result: map[string]string{
 				constants.ConfigStream:         "registry.example.org/test-stream",
 				constants.ConfigFleetlockURL:   "https://fleetlock.example.org",
 				constants.ConfigFleetlockGroup: "default",
-				constants.ConfigCheckInterval:  "2m0s",
-				constants.ConfigRetryInterval:  "3m0s",
+				constants.ConfigCheckInterval:  "2m",
+				constants.ConfigRetryInterval:  "3m",
 			},
 		},
 		{
@@ -67,8 +66,8 @@ func TestCombineConfig(t *testing.T) {
 				Stream:         "registry.example.org/test-stream",
 				FleetlockURL:   "https://fleetlock.example.org",
 				FleetlockGroup: "not-default",
-				CheckInterval:  time.Minute * 10,
-				RetryInterval:  time.Minute * 15,
+				CheckInterval:  "10m",
+				RetryInterval:  "15m",
 			},
 			Group: &api.UpgradedConfig{
 				Stream:       "registry.example.com/test-stream",
@@ -78,8 +77,8 @@ func TestCombineConfig(t *testing.T) {
 				constants.ConfigStream:         "registry.example.com/test-stream",
 				constants.ConfigFleetlockURL:   "https://fleetlock.example.com",
 				constants.ConfigFleetlockGroup: "not-default",
-				constants.ConfigCheckInterval:  "10m0s",
-				constants.ConfigRetryInterval:  "15m0s",
+				constants.ConfigCheckInterval:  "10m",
+				constants.ConfigRetryInterval:  "15m",
 			},
 		},
 		{
@@ -88,15 +87,15 @@ func TestCombineConfig(t *testing.T) {
 				Stream:         "registry.example.com/test-stream",
 				FleetlockURL:   "https://fleetlock.example.com",
 				FleetlockGroup: "default",
-				CheckInterval:  time.Minute * 2,
-				RetryInterval:  time.Minute * 3,
+				CheckInterval:  "2m",
+				RetryInterval:  "3m",
 			},
 			Result: map[string]string{
 				constants.ConfigStream:         "registry.example.com/test-stream",
 				constants.ConfigFleetlockURL:   "https://fleetlock.example.com",
 				constants.ConfigFleetlockGroup: "default",
-				constants.ConfigCheckInterval:  "2m0s",
-				constants.ConfigRetryInterval:  "3m0s",
+				constants.ConfigCheckInterval:  "2m",
+				constants.ConfigRetryInterval:  "3m",
 			},
 		},
 		{
@@ -105,15 +104,15 @@ func TestCombineConfig(t *testing.T) {
 				Stream:         "registry.example.com/test-stream",
 				FleetlockURL:   "https://fleetlock.example.com",
 				FleetlockGroup: "default",
-				CheckInterval:  time.Minute * 2,
-				RetryInterval:  time.Minute * 3,
+				CheckInterval:  "2m",
+				RetryInterval:  "3m",
 			},
 			Result: map[string]string{
 				constants.ConfigStream:         "registry.example.com/test-stream",
 				constants.ConfigFleetlockURL:   "https://fleetlock.example.com",
 				constants.ConfigFleetlockGroup: "default",
-				constants.ConfigCheckInterval:  "2m0s",
-				constants.ConfigRetryInterval:  "3m0s",
+				constants.ConfigCheckInterval:  "2m",
+				constants.ConfigRetryInterval:  "3m",
 			},
 		},
 		{

--- a/pkg/upgrade-controller/controller/controller_test.go
+++ b/pkg/upgrade-controller/controller/controller_test.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"testing"
-	"time"
 
 	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha1"
 	"github.com/heathcliff26/kube-upgrade/pkg/constants"
@@ -438,8 +437,8 @@ func TestReconcile(t *testing.T) {
 						Stream:         "registry.example.com/test-stream",
 						FleetlockURL:   "https://fleetlock.example.org",
 						FleetlockGroup: "default",
-						CheckInterval:  time.Minute * 2,
-						RetryInterval:  time.Minute * 3,
+						CheckInterval:  "2m",
+						RetryInterval:  "3m",
 					},
 					Groups: map[string]api.KubeUpgradePlanGroup{
 						"control": {
@@ -490,8 +489,8 @@ func TestReconcile(t *testing.T) {
 				constants.ConfigStream:          "registry.example.com/test-stream",
 				constants.ConfigFleetlockURL:    "https://fleetlock.example.org",
 				constants.ConfigFleetlockGroup:  "control-plane",
-				constants.ConfigCheckInterval:   "2m0s",
-				constants.ConfigRetryInterval:   "3m0s",
+				constants.ConfigCheckInterval:   "2m",
+				constants.ConfigRetryInterval:   "3m",
 			},
 			ExpectedAnnotationsCompute: map[string]string{
 				constants.NodeKubernetesVersion: "v1.30.4",
@@ -499,8 +498,8 @@ func TestReconcile(t *testing.T) {
 				constants.ConfigStream:          "registry.example.com/test-stream",
 				constants.ConfigFleetlockURL:    "https://fleetlock.example.org",
 				constants.ConfigFleetlockGroup:  "compute",
-				constants.ConfigCheckInterval:   "2m0s",
-				constants.ConfigRetryInterval:   "3m0s",
+				constants.ConfigCheckInterval:   "2m",
+				constants.ConfigRetryInterval:   "3m",
 			},
 		},
 	}


### PR DESCRIPTION
Change interval types/format to string/duration instead of integer/int64.