### PR TITLE
upgraded: Fix endless upgrade loop

### DIFF
--- a/pkg/upgraded/daemon/config.go
+++ b/pkg/upgraded/daemon/config.go
@@ -6,13 +6,12 @@ import (
 	"time"
 
 	"github.com/heathcliff26/kube-upgrade/pkg/constants"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Update the daemon configuration based on the annotations of the node.
 // Returns on the first error, but will change all configs before that.
 func (d *daemon) UpdateConfigFromNode() error {
-	node, err := d.client.CoreV1().Nodes().Get(d.ctx, d.node, metav1.GetOptions{})
+	node, err := d.getNode()
 	if err != nil {
 		return err
 	}

--- a/pkg/upgraded/daemon/nodes_test.go
+++ b/pkg/upgraded/daemon/nodes_test.go
@@ -15,14 +15,6 @@ import (
 )
 
 func TestDoNodeUpgrade(t *testing.T) {
-	t.Run("MutexAlreadyHeld", func(t *testing.T) {
-		d := &daemon{}
-
-		d.upgrade.Lock()
-		t.Cleanup(d.upgrade.Unlock)
-
-		assert.NoError(t, d.doNodeUpgrade(nil), "Should simply exit without doing anything")
-	})
 	t.Run("LockAlreadyReserved", func(t *testing.T) {
 		assert := assert.New(t)
 

--- a/pkg/upgraded/daemon/stream.go
+++ b/pkg/upgraded/daemon/stream.go
@@ -46,11 +46,7 @@ func (d *daemon) watchForUpgrade() {
 
 // Perform rpm-ostree upgrade
 func (d *daemon) doUpgrade() error {
-	// There should ever only be one upgrade at a time and any upgrade comes with a reboot anyway.
-	// So the best option here is to just silently return if the lock is already held.
-	if !d.upgrade.TryLock() {
-		return nil
-	}
+	d.upgrade.Lock()
 	defer d.upgrade.Unlock()
 
 	err := d.UpdateConfigFromNode()

--- a/pkg/upgraded/daemon/stream_test.go
+++ b/pkg/upgraded/daemon/stream_test.go
@@ -68,14 +68,6 @@ func TestDoUpgrade(t *testing.T) {
 
 		assert.Error(err, "Should exit with error")
 	})
-	t.Run("MutexAlreadyHeld", func(t *testing.T) {
-		d := &daemon{}
-
-		d.upgrade.Lock()
-		t.Cleanup(d.upgrade.Unlock)
-
-		assert.NoError(t, d.doUpgrade(), "Should simply exit without doing anything")
-	})
 	// This case is kinda scetchy, as in reality the system would reboot on success, thus the method should never return
 	t.Run("Success", func(t *testing.T) {
 		assert := assert.New(t)


### PR DESCRIPTION
Fetch the current node status from API server before performing upgrade to ensure no upgrade is performed based on stale data. Perform initial upgrade if it is needed on startup.

Fixes: #35