### PR TITLE
upgrade-controller: Remove status updates from mutatingwebhook

### DIFF
--- a/pkg/apis/kubeupgrade/v1alpha1/defaults.go
+++ b/pkg/apis/kubeupgrade/v1alpha1/defaults.go
@@ -33,12 +33,3 @@ func SetObjectDefaults_UpgradedConfig(cfg *UpgradedConfig) {
 		cfg.RetryInterval = "5m"
 	}
 }
-
-func SetObjectDefaults_KubeUpgradeStatus(status *KubeUpgradeStatus) {
-	if status.Summary == "" {
-		status.Summary = DefaultStatus
-	}
-	if status.Groups == nil {
-		status.Groups = make(map[string]string)
-	}
-}

--- a/pkg/apis/kubeupgrade/v1alpha1/types.go
+++ b/pkg/apis/kubeupgrade/v1alpha1/types.go
@@ -72,7 +72,6 @@ type KubeUpgradePlanGroup struct {
 type KubeUpgradeStatus struct {
 	// A summary of the overall status of the cluster
 	// +kubebuilder:validation:Enum=Unknown;Waiting;Progressing;Complete
-	// +default="Unknown"
 	Summary string `json:"summary,omitempty"`
 
 	// The current status of each group

--- a/pkg/apis/kubeupgrade/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/kubeupgrade/v1alpha1/zz_generated.defaults.go
@@ -20,7 +20,6 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_KubeUpgradePlan(in *KubeUpgradePlan) {
 	SetObjectDefaults_KubeUpgradeSpec(&in.Spec)
-	SetObjectDefaults_KubeUpgradeStatus(&in.Status)
 }
 
 func SetObjectDefaults_KubeUpgradePlanList(in *KubeUpgradePlanList) {

--- a/pkg/upgrade-controller/controller/mutatingwebhook.go
+++ b/pkg/upgrade-controller/controller/mutatingwebhook.go
@@ -22,16 +22,5 @@ func (*planMutatingHook) Default(_ context.Context, obj runtime.Object) error {
 
 	api.SetObjectDefaults_KubeUpgradePlan(plan)
 
-	for group := range plan.Status.Groups {
-		if _, ok := plan.Spec.Groups[group]; !ok {
-			delete(plan.Status.Groups, group)
-		}
-	}
-	for group := range plan.Spec.Groups {
-		if plan.Status.Groups[group] == "" {
-			plan.Status.Groups[group] = api.DefaultStatus
-		}
-	}
-
 	return nil
 }

--- a/pkg/upgrade-controller/controller/mutatingwebhook_test.go
+++ b/pkg/upgrade-controller/controller/mutatingwebhook_test.go
@@ -21,10 +21,6 @@ func TestDefault(t *testing.T) {
 				Spec: api.KubeUpgradeSpec{
 					Groups: map[string]api.KubeUpgradePlanGroup{},
 				},
-				Status: api.KubeUpgradeStatus{
-					Summary: api.DefaultStatus,
-					Groups:  map[string]string{},
-				},
 			},
 		},
 		{
@@ -42,12 +38,6 @@ func TestDefault(t *testing.T) {
 						"control-plane": {
 							Labels: map[string]string{},
 						},
-					},
-				},
-				Status: api.KubeUpgradeStatus{
-					Summary: api.DefaultStatus,
-					Groups: map[string]string{
-						"control-plane": api.DefaultStatus,
 					},
 				},
 			},
@@ -77,44 +67,6 @@ func TestDefault(t *testing.T) {
 						FleetlockGroup: "default",
 						CheckInterval:  "3h",
 						RetryInterval:  "5m",
-					},
-				},
-				Status: api.KubeUpgradeStatus{
-					Summary: api.DefaultStatus,
-					Groups: map[string]string{
-						"control-plane": api.DefaultStatus,
-					},
-				},
-			},
-		},
-		{
-			Name: "PruneGroupStatus",
-			Plan: &api.KubeUpgradePlan{
-				Spec: api.KubeUpgradeSpec{
-					Groups: map[string]api.KubeUpgradePlanGroup{
-						"control-plane": {},
-					},
-				},
-				Status: api.KubeUpgradeStatus{
-					Summary: api.DefaultStatus,
-					Groups: map[string]string{
-						"control-plane": api.DefaultStatus,
-						"compute":       api.DefaultStatus,
-					},
-				},
-			},
-			Result: &api.KubeUpgradePlan{
-				Spec: api.KubeUpgradeSpec{
-					Groups: map[string]api.KubeUpgradePlanGroup{
-						"control-plane": {
-							Labels: map[string]string{},
-						},
-					},
-				},
-				Status: api.KubeUpgradeStatus{
-					Summary: api.DefaultStatus,
-					Groups: map[string]string{
-						"control-plane": api.DefaultStatus,
 					},
 				},
 			},


### PR DESCRIPTION
Mutating webhooks in kubernetes can't modify the status, so there is no need to have the code in here.