### PR TITLE
e2e: Do not cache results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ fmt:
 	gofmt -s -w ./cmd ./pkg
 
 e2e:
-	go test -v ./tests/...
+	go test -count=1 -v ./tests/...
 
 clean:
 	rm -rf bin manifests/release coverprofiles logs tmp_controller_image_kube-upgrade-e2e-*.tar


### PR DESCRIPTION
Since the e2e test result can change independent of go code changes, for example by changing the manifests, it should not be cached.