### PR TITLE
api: Remove status value restrictions

### DIFF
--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -350,11 +350,6 @@ spec:
                 type: object
               summary:
                 description: A summary of the overall status of the cluster
-                enum:
-                - Unknown
-                - Waiting
-                - Progressing
-                - Complete
                 type: string
             type: object
         required:

--- a/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
+++ b/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
@@ -345,11 +345,6 @@ spec:
                 type: object
               summary:
                 description: A summary of the overall status of the cluster
-                enum:
-                - Unknown
-                - Waiting
-                - Progressing
-                - Complete
                 type: string
             type: object
         required:

--- a/manifests/generated/kubeupgradeplan_v1alpha2.json
+++ b/manifests/generated/kubeupgradeplan_v1alpha2.json
@@ -178,12 +178,6 @@
         },
         "summary": {
           "description": "A summary of the overall status of the cluster",
-          "enum": [
-            "Unknown",
-            "Waiting",
-            "Progressing",
-            "Complete"
-          ],
           "type": "string"
         }
       },

--- a/pkg/apis/kubeupgrade/v1alpha2/types.go
+++ b/pkg/apis/kubeupgrade/v1alpha2/types.go
@@ -71,7 +71,6 @@ type KubeUpgradePlanGroup struct {
 
 type KubeUpgradeStatus struct {
 	// A summary of the overall status of the cluster
-	// +kubebuilder:validation:Enum=Unknown;Waiting;Progressing;Complete
 	Summary string `json:"summary,omitempty"`
 
 	// The current status of each group

--- a/pkg/apis/kubeupgrade/v1alpha2/validation.go
+++ b/pkg/apis/kubeupgrade/v1alpha2/validation.go
@@ -4,23 +4,13 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
-	"slices"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
-	validStatusValues = []string{"Unknown", "Waiting", "Progressing", "Complete"}
-)
-
 func ValidateObject_KubeUpgradePlan(plan *KubeUpgradePlan) error {
-	err := ValidateObject_KubeUpgradeSpec(plan.Spec)
-	if err != nil {
-		return err
-	}
-
-	return ValidateObject_KubeUpgradeStatus(plan.Status)
+	return ValidateObject_KubeUpgradeSpec(plan.Spec)
 }
 
 func ValidateObject_KubeUpgradeSpec(spec KubeUpgradeSpec) error {
@@ -92,25 +82,6 @@ func ValidateObject_UpgradedConfig(cfg UpgradedConfig) error {
 		_, err := time.ParseDuration(cfg.RetryInterval)
 		if err != nil {
 			return fmt.Errorf("invalid input \"%s\" for retry-interval: %v", cfg.RetryInterval, err)
-		}
-	}
-
-	return nil
-}
-
-func ValidateObject_KubeUpgradeStatus(status KubeUpgradeStatus) error {
-	// Mutating/Validation webhooks for subresources are called later, so it is ok if the status does not exist
-	if status.Summary == "" && len(status.Groups) == 0 {
-		return nil
-	}
-
-	if !slices.Contains(validStatusValues, status.Summary) {
-		return fmt.Errorf("found unknown status \"%s\" in summary, accepted values are: %v", status.Summary, validStatusValues)
-	}
-
-	for group, value := range status.Groups {
-		if !slices.Contains(validStatusValues, value) {
-			return fmt.Errorf("found unknown status \"%s\" in group \"%s\", accepted values are: %v", value, group, validStatusValues)
 		}
 	}
 

--- a/pkg/upgrade-controller/controller/validatingwebhook_test.go
+++ b/pkg/upgrade-controller/controller/validatingwebhook_test.go
@@ -61,9 +61,6 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
-	validWithStatus := minimumValidPlan.DeepCopy()
-	validWithStatus.Status.Summary = "Complete"
-
 	invalidKubernetesVersion := minimumValidPlan.DeepCopy()
 	invalidKubernetesVersion.Spec.KubernetesVersion = "testv1.0.0"
 
@@ -135,13 +132,6 @@ func TestValidate(t *testing.T) {
 	invalidRetryInterval := minimumValidPlan.DeepCopy()
 	invalidRetryInterval.Spec.Upgraded.RetryInterval = "not-a-duration"
 
-	invalidStatusSummary := minimumValidPlan.DeepCopy()
-	invalidStatusSummary.Status.Summary = "invalid-status"
-
-	invalidGroupStatus := minimumValidPlan.DeepCopy()
-	invalidGroupStatus.Status.Summary = "Unknown"
-	invalidGroupStatus.Status.Groups = map[string]string{"control-plane": "invalid-status"}
-
 	tMatrix := []struct {
 		Name  string
 		Plan  *api.KubeUpgradePlan
@@ -163,10 +153,6 @@ func TestValidate(t *testing.T) {
 		{
 			Name: "ValidGroupWithUpgradedConfig",
 			Plan: validGroupWithUpgradedConfig,
-		},
-		{
-			Name: "ValidWithStatus",
-			Plan: validWithStatus,
 		},
 		{
 			Name:  "InvalidKubernetesVersion",
@@ -226,16 +212,6 @@ func TestValidate(t *testing.T) {
 		{
 			Name:  "InvalidRetryInterval",
 			Plan:  invalidRetryInterval,
-			Error: true,
-		},
-		{
-			Name:  "InvalidStatusSummary",
-			Plan:  invalidStatusSummary,
-			Error: true,
-		},
-		{
-			Name:  "InvalidGroupStatus",
-			Plan:  invalidGroupStatus,
 			Error: true,
 		},
 	}


### PR DESCRIPTION
The status is controlled by the controller itself, so there is no need to restrict it's values.