### PR TITLE
controller: Drop unnecessary status subresource from validating webhook

### DIFF
--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -515,7 +515,6 @@ webhooks:
           - UPDATE
         resources:
           - kubeupgradeplans
-          - kubeupgradeplans/status
     sideEffects: None
 ---
 apiVersion: apps/v1

--- a/manifests/generated/manifests.yaml
+++ b/manifests/generated/manifests.yaml
@@ -53,5 +53,4 @@ webhooks:
           - UPDATE
         resources:
           - kubeupgradeplans
-          - kubeupgradeplans/status
     sideEffects: None

--- a/pkg/upgrade-controller/controller/validatingwebhook.go
+++ b/pkg/upgrade-controller/controller/validatingwebhook.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// +kubebuilder:webhook:path=/validate-kubeupgrade-heathcliff-eu-v1alpha2-kubeupgradeplan,mutating=false,failurePolicy=fail,groups=kubeupgrade.heathcliff.eu,resources=kubeupgradeplans;kubeupgradeplans/status,verbs=create;update,versions=v1alpha2,name=kubeupgrade.heathcliff.eu,admissionReviewVersions=v1,sideEffects=None
+// +kubebuilder:webhook:path=/validate-kubeupgrade-heathcliff-eu-v1alpha2-kubeupgradeplan,mutating=false,failurePolicy=fail,groups=kubeupgrade.heathcliff.eu,resources=kubeupgradeplans,verbs=create;update,versions=v1alpha2,name=kubeupgrade.heathcliff.eu,admissionReviewVersions=v1,sideEffects=None
 
 // planValidatingHook validates the plan
 type planValidatingHook struct{}


### PR DESCRIPTION
Since the status does not get validated, there is no need for the validating webhook to check the status subresource.