### PR TITLE
upgrade-controller: Add downgrade protection

### DIFF
--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -204,6 +204,11 @@ spec:
             type: object
           spec:
             properties:
+              allowDowngrade:
+                description: |-
+                  Allow downgrading to older kubernetes versions.
+                  Only enable if you know what you are doing.
+                type: boolean
               groups:
                 additionalProperties:
                   properties:
@@ -305,7 +310,7 @@ spec:
               kubernetesVersion:
                 description: |-
                   The kubernetes version the cluster should be at.
-                  If the actual version differs, the cluster will be upgraded
+                  If the actual version differs, the cluster will be upgraded.
                 example: v1.31.0
                 format: semver
                 type: string

--- a/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
+++ b/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
@@ -199,6 +199,11 @@ spec:
             type: object
           spec:
             properties:
+              allowDowngrade:
+                description: |-
+                  Allow downgrading to older kubernetes versions.
+                  Only enable if you know what you are doing.
+                type: boolean
               groups:
                 additionalProperties:
                   properties:
@@ -300,7 +305,7 @@ spec:
               kubernetesVersion:
                 description: |-
                   The kubernetes version the cluster should be at.
-                  If the actual version differs, the cluster will be upgraded
+                  If the actual version differs, the cluster will be upgraded.
                 example: v1.31.0
                 format: semver
                 type: string

--- a/manifests/generated/kubeupgradeplan_v1alpha2.json
+++ b/manifests/generated/kubeupgradeplan_v1alpha2.json
@@ -13,6 +13,10 @@
     },
     "spec": {
       "properties": {
+        "allowDowngrade": {
+          "description": "Allow downgrading to older kubernetes versions.\nOnly enable if you know what you are doing.",
+          "type": "boolean"
+        },
         "groups": {
           "additionalProperties": {
             "properties": {
@@ -120,7 +124,7 @@
           "type": "object"
         },
         "kubernetesVersion": {
-          "description": "The kubernetes version the cluster should be at.\nIf the actual version differs, the cluster will be upgraded",
+          "description": "The kubernetes version the cluster should be at.\nIf the actual version differs, the cluster will be upgraded.",
           "example": "v1.31.0",
           "format": "semver",
           "type": "string"

--- a/pkg/apis/kubeupgrade/v1alpha2/types.go
+++ b/pkg/apis/kubeupgrade/v1alpha2/types.go
@@ -34,11 +34,17 @@ type KubeUpgradePlan struct {
 
 type KubeUpgradeSpec struct {
 	// The kubernetes version the cluster should be at.
-	// If the actual version differs, the cluster will be upgraded
+	// If the actual version differs, the cluster will be upgraded.
 	// +required
 	// +kubebuilder:validation:Format=semver
 	// +kubebuilder:example=v1.31.0
 	KubernetesVersion string `json:"kubernetesVersion"`
+
+	// Allow downgrading to older kubernetes versions.
+	// Only enable if you know what you are doing.
+	// +optional
+	// +default=false
+	AllowDowngrade bool `json:"allowDowngrade,omitempty"`
 
 	// The different groups in which the nodes will be upgraded.
 	// At minimum needs to separate control-plane from compute nodes, to ensure that control-plane nodes will be upgraded first.

--- a/pkg/client/applyconfiguration/kubeupgrade/v1alpha2/kubeupgradespec.go
+++ b/pkg/client/applyconfiguration/kubeupgrade/v1alpha2/kubeupgradespec.go
@@ -6,6 +6,7 @@ package v1alpha2
 // with apply.
 type KubeUpgradeSpecApplyConfiguration struct {
 	KubernetesVersion *string                                           `json:"kubernetesVersion,omitempty"`
+	AllowDowngrade    *bool                                             `json:"allowDowngrade,omitempty"`
 	Groups            map[string]KubeUpgradePlanGroupApplyConfiguration `json:"groups,omitempty"`
 	Upgraded          *UpgradedConfigApplyConfiguration                 `json:"upgraded,omitempty"`
 }
@@ -21,6 +22,14 @@ func KubeUpgradeSpec() *KubeUpgradeSpecApplyConfiguration {
 // If called multiple times, the KubernetesVersion field is set to the value of the last call.
 func (b *KubeUpgradeSpecApplyConfiguration) WithKubernetesVersion(value string) *KubeUpgradeSpecApplyConfiguration {
 	b.KubernetesVersion = &value
+	return b
+}
+
+// WithAllowDowngrade sets the AllowDowngrade field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AllowDowngrade field is set to the value of the last call.
+func (b *KubeUpgradeSpecApplyConfiguration) WithAllowDowngrade(value bool) *KubeUpgradeSpecApplyConfiguration {
+	b.AllowDowngrade = &value
 	return b
 }
 


### PR DESCRIPTION
Implement downgrade protection for the controller, to ensure nodes are not upgraded to an older version.
Add api option for allowing downgrades if it is required.