### PR TITLE
upgraded: Fix nil pointer panic when logging error

### DIFF
--- a/pkg/upgraded/daemon/nodes.go
+++ b/pkg/upgraded/daemon/nodes.go
@@ -59,7 +59,7 @@ func (d *daemon) doNodeUpgradeWithRetry(node *corev1.Node) {
 		if err == nil {
 			return true
 		}
-		slog.Error("Failed to upgrade node", "err", err, slog.String("node", node.GetName()))
+		slog.Error("Failed to upgrade node", "err", err, slog.String("node", d.node))
 		return false
 	})
 }

--- a/pkg/upgraded/daemon/nodes_test.go
+++ b/pkg/upgraded/daemon/nodes_test.go
@@ -15,6 +15,29 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+func TestDoNodeUpgradeWithRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	d := &daemon{
+		client:        fake.NewSimpleClientset(),
+		node:          "not-a-node",
+		ctx:           ctx,
+		retryInterval: time.Second,
+	}
+
+	done := make(chan struct{}, 1)
+	go func() {
+		// Should not panic with nil
+		d.doNodeUpgradeWithRetry(nil)
+	}()
+	t.Cleanup(cancel)
+
+	select {
+	case <-done:
+		t.Fatal("The upgrade should not succeed")
+	case <-time.After(time.Second * 3):
+	}
+}
+
 func TestDoNodeUpgrade(t *testing.T) {
 	t.Run("LockAlreadyReserved", func(t *testing.T) {
 		assert := assert.New(t)


### PR DESCRIPTION
Fix a potential nil pointer panic when logging an error during node upgrades.

Fixes: #44