### PR TITLE
api: Change duration to go-duration

### DIFF
--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -277,7 +277,7 @@ spec:
                         check-interval:
                           description: The interval between regular checks
                           example: 3h;24h;30m
-                          format: duration
+                          format: go-duration
                           type: string
                         fleetlock-group:
                           description: The group to use for fleetlock
@@ -292,7 +292,7 @@ spec:
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
-                          format: duration
+                          format: go-duration
                           type: string
                         stream:
                           description: The container image repository for os rebases
@@ -321,7 +321,7 @@ spec:
                   check-interval:
                     description: The interval between regular checks
                     example: 3h;24h;30m
-                    format: duration
+                    format: go-duration
                     type: string
                   fleetlock-group:
                     description: The group to use for fleetlock
@@ -335,7 +335,7 @@ spec:
                   retry-interval:
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
-                    format: duration
+                    format: go-duration
                     type: string
                   stream:
                     description: The container image repository for os rebases

--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-#!/bin/bash
-
 set -e
 
 script_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)"
-base_dir="${script_dir}/.."
+
+if ! command -v kubeconform 2>&1 >/dev/null; then
+    go install github.com/yannh/kubeconform/cmd/kubeconform@latest
+fi
 
 echo "Check if source code is formatted"
 make fmt
@@ -37,3 +38,6 @@ if [ $rc -ne 0 ]; then
     echo "FATAL: Need to run \"make manifests\" and update the examples with the result"
     exit 1
 fi
+
+echo "Check if the generated example plan is conform"
+kubeconform -schema-location manifests/generated/kubeupgradeplan_v1alpha2.json -verbose -strict examples/upgrade-controller/upgrade-cr.yaml

--- a/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
+++ b/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
@@ -272,7 +272,7 @@ spec:
                         check-interval:
                           description: The interval between regular checks
                           example: 3h;24h;30m
-                          format: duration
+                          format: go-duration
                           type: string
                         fleetlock-group:
                           description: The group to use for fleetlock
@@ -287,7 +287,7 @@ spec:
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
-                          format: duration
+                          format: go-duration
                           type: string
                         stream:
                           description: The container image repository for os rebases
@@ -316,7 +316,7 @@ spec:
                   check-interval:
                     description: The interval between regular checks
                     example: 3h;24h;30m
-                    format: duration
+                    format: go-duration
                     type: string
                   fleetlock-group:
                     description: The group to use for fleetlock
@@ -330,7 +330,7 @@ spec:
                   retry-interval:
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
-                    format: duration
+                    format: go-duration
                     type: string
                   stream:
                     description: The container image repository for os rebases

--- a/manifests/generated/kubeupgradeplan_v1alpha2.json
+++ b/manifests/generated/kubeupgradeplan_v1alpha2.json
@@ -84,7 +84,7 @@
                   "check-interval": {
                     "description": "The interval between regular checks",
                     "example": "3h;24h;30m",
-                    "format": "duration",
+                    "format": "go-duration",
                     "type": "string"
                   },
                   "fleetlock-group": {
@@ -100,7 +100,7 @@
                   "retry-interval": {
                     "description": "The interval between retries when an operation fails",
                     "example": "5m;1m;30s",
-                    "format": "duration",
+                    "format": "go-duration",
                     "type": "string"
                   },
                   "stream": {
@@ -135,7 +135,7 @@
             "check-interval": {
               "description": "The interval between regular checks",
               "example": "3h;24h;30m",
-              "format": "duration",
+              "format": "go-duration",
               "type": "string"
             },
             "fleetlock-group": {
@@ -151,7 +151,7 @@
             "retry-interval": {
               "description": "The interval between retries when an operation fails",
               "example": "5m;1m;30s",
-              "format": "duration",
+              "format": "go-duration",
               "type": "string"
             },
             "stream": {

--- a/pkg/apis/kubeupgrade/v1alpha2/types.go
+++ b/pkg/apis/kubeupgrade/v1alpha2/types.go
@@ -103,14 +103,14 @@ type UpgradedConfig struct {
 
 	// The interval between regular checks
 	// +optional
-	// +kubebuilder:validation:Format=duration
+	// +kubebuilder:validation:Format=go-duration
 	// +default="3h"
 	// +kubebuilder:example="3h;24h;30m"
 	CheckInterval string `json:"check-interval,omitempty"`
 
 	// The interval between retries when an operation fails
 	// +optional
-	// +kubebuilder:validation:Format=duration
+	// +kubebuilder:validation:Format=go-duration
 	// +default="5m"
 	// +kubebuilder:example="5m;1m;30s"
 	RetryInterval string `json:"retry-interval,omitempty"`


### PR DESCRIPTION
The duration format for openapi is not compatible with the duration string
format used by go. Change the format in the api specification to reflect this.
This fixes failing kubeconform validation for custom durations.

hack/validate.sh: Add step for testing example plan with kubeconform