### PR TITLE
upgraded: Fix permission issue with k8s 1.32

### DIFF
--- a/pkg/upgraded/daemon/daemon.go
+++ b/pkg/upgraded/daemon/daemon.go
@@ -81,7 +81,7 @@ func NewDaemon(cfg *config.Config) (*daemon, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get machine-id: %v", err)
 	}
-	node, err := findNodeByMachineID(kubeClient, machineID)
+	node, err := findNode(kubeClient, machineID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kubernetes node name for host: %v", err)
 	}

--- a/pkg/upgraded/daemon/utils.go
+++ b/pkg/upgraded/daemon/utils.go
@@ -4,15 +4,52 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/heathcliff26/kube-upgrade/pkg/constants"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-// Find the node by it's machine ID
-func findNodeByMachineID(client kubernetes.Interface, machineID string) (string, error) {
+// Find the node. It will try various methods and confirm them via the machine id.
+// The methods are in order:
+//   - whoami api call
+//   - listing all nodes and iterating over them. (This does not work anymore with k8s 1.32+)
+func findNode(client kubernetes.Interface, machineID string) (string, error) {
+	node, err := findNodeViaWhoami(client, machineID)
+	if err == nil {
+		return node, nil
+	}
+	slog.Info("Failed to find node via whoami call, trying by listing all nodes next", "err", err)
+
+	return findNodeByListingAllNodes(client, machineID)
+}
+
+// Call kubernetes auth api and ask whoami
+func findNodeViaWhoami(client kubernetes.Interface, machineID string) (string, error) {
+	res, err := client.AuthenticationV1().SelfSubjectReviews().Create(context.Background(), &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	name, _ := strings.CutPrefix(res.Status.UserInfo.Username, "system:node:")
+	slog.Info("Found username via auth whoami", slog.String("username", res.Status.UserInfo.Username), slog.String("node", name))
+
+	node, err := client.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	if node.Status.NodeInfo.MachineID != machineID {
+		return "", fmt.Errorf("found node \"%s\", but machine id does not match", name)
+	}
+	return name, nil
+}
+
+// Find the node by iterating over all nodes and comparing machine ids
+func findNodeByListingAllNodes(client kubernetes.Interface, machineID string) (string, error) {
 	nodes, err := client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return "", err

--- a/pkg/upgraded/daemon/utils_test.go
+++ b/pkg/upgraded/daemon/utils_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestFindNodeByMachineID(t *testing.T) {
+func TestFindNodeByListingAllNodes(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -25,7 +25,7 @@ func TestFindNodeByMachineID(t *testing.T) {
 	}
 	_, _ = client.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
 
-	res, err := findNodeByMachineID(client, "1234567890")
+	res, err := findNodeByListingAllNodes(client, "1234567890")
 
 	assert := assert.New(t)
 


### PR DESCRIPTION
When running on 1.32, the worker nodes no longer have permission to list all nodes. To fix this, upgraded uses the auth api to find the node name via the current username.

Fixes: #76