### PR TITLE
upgrade-controller: Do not pin builder image sha

### DIFF
--- a/cmd/upgrade-controller/Dockerfile
+++ b/cmd/upgrade-controller/Dockerfile
@@ -1,7 +1,7 @@
 ###############################################################################
 # BEGIN build-stage
 # Compile the binary
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23.4@sha256:7ea4c9dcb2b97ff8ee80a67db3d44f98c8ffa0d191399197007d8459c1453041 AS build-stage
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23.4 AS build-stage
 
 ARG BUILDPLATFORM
 ARG TARGETARCH


### PR DESCRIPTION
There is no reason to pin the golang image to a sha, as the only relevant part is the golang version.