### PR TITLE
version: Use the version from build info

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,11 +13,6 @@ GOARCH="${GOARCH:-$(go env GOARCH)}"
 
 GO_LD_FLAGS="${GO_LD_FLAGS:-"-s"}"
 
-if [ "${RELEASE_VERSION}" != "" ]; then
-    echo "Building release version ${RELEASE_VERSION}"
-    GO_LD_FLAGS+=" -X github.com/heathcliff26/kube-upgrade/pkg/version.version=${RELEASE_VERSION}"
-fi
-
 output_name="${bin_dir}/${target}"
 
 if [ "${2}" != "" ]; then

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,8 +8,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "devel"
-
 // Create a new version command with the given app name
 func NewCommand(name string) *cobra.Command {
 	cmd := &cobra.Command{
@@ -27,7 +25,8 @@ func NewCommand(name string) *cobra.Command {
 
 // Return the version string
 func Version() string {
-	return version
+	buildinfo, _ := debug.ReadBuildInfo()
+	return buildinfo.Main.Version
 }
 
 // Return a formated string containing the version, git commit and go version the app was compiled with.
@@ -47,7 +46,7 @@ func VersionInfoString(name string) string {
 	}
 
 	result := name + ":\n"
-	result += "    Version: " + version + "\n"
+	result += "    Version: " + buildinfo.Main.Version + "\n"
 	result += "    Commit:  " + commit + "\n"
 	result += "    Go:      " + runtime.Version() + "\n"
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"testing"
 
@@ -20,14 +21,9 @@ func TestNewVersionCommand(t *testing.T) {
 func TestVersion(t *testing.T) {
 	assert := assert.New(t)
 
-	oldVersion := version
-	t.Cleanup(func() {
-		version = oldVersion
-	})
+	buildinfo, _ := debug.ReadBuildInfo()
 
-	version = "v0.0.0-unit-test"
-
-	assert.Equal(version, Version(), "Version should return the content of the version variable")
+	assert.Equal(buildinfo.Main.Version, Version(), "Version should return the version from build info")
 }
 
 func TestVersionInfoString(t *testing.T) {
@@ -37,11 +33,13 @@ func TestVersionInfoString(t *testing.T) {
 
 	assert := assert.New(t)
 
+	buildinfo, _ := debug.ReadBuildInfo()
+
 	if !assert.Equal(5, len(lines), "Should have enough lines") {
 		t.FailNow()
 	}
 	assert.Contains(lines[0], "test")
-	assert.Contains(lines[1], version)
+	assert.Contains(lines[1], buildinfo.Main.Version)
 
 	commit := strings.Split(lines[2], ":")
 	assert.NotEmpty(strings.TrimSpace(commit[1]))


### PR DESCRIPTION
With golang 1.24, the version derived from tag is now embedded by default. Use it instead, as it is better and easier than stamping it manually during build.