### PR TITLE
upgrade-controller: Copy whole repo for building image

### DIFF
--- a/cmd/upgrade-controller/Dockerfile
+++ b/cmd/upgrade-controller/Dockerfile
@@ -9,13 +9,9 @@ ARG RELEASE_VERSION
 
 WORKDIR /app
 
-COPY vendor ./vendor
-COPY go.mod go.sum ./
-COPY cmd ./cmd
-COPY pkg ./pkg
-COPY hack ./hack
+COPY . ./
 
-RUN --mount=type=bind,target=/app/.git,source=.git GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh upgrade-controller
+RUN GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh upgrade-controller
 
 #
 # END build-stage


### PR DESCRIPTION
When building the image, copy the whole repository, to ensure the correct version information is used for stamping.