### PR TITLE
unit-test: Use context scoped to current test

### DIFF
--- a/pkg/upgrade-controller/controller/mutatingwebhook_test.go
+++ b/pkg/upgrade-controller/controller/mutatingwebhook_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"testing"
 
 	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha2"
@@ -110,13 +109,13 @@ func TestDefault(t *testing.T) {
 		t.Run(tCase.Name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			err := (&planMutatingHook{}).Default(context.Background(), tCase.Plan)
+			err := (&planMutatingHook{}).Default(t.Context(), tCase.Plan)
 
 			assert.NoError(err, "Should succeed")
 			assert.Equal(tCase.Result, tCase.Plan)
 		})
 	}
 	t.Run("InvalidObject", func(t *testing.T) {
-		assert.Error(t, (&planMutatingHook{}).Default(context.Background(), &corev1.Pod{}), "Should return an error")
+		assert.Error(t, (&planMutatingHook{}).Default(t.Context(), &corev1.Pod{}), "Should return an error")
 	})
 }

--- a/pkg/upgrade-controller/controller/validatingwebhook_test.go
+++ b/pkg/upgrade-controller/controller/validatingwebhook_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"testing"
 
 	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha2"
@@ -235,7 +234,7 @@ func TestValidate(t *testing.T) {
 		t.Run(tCase.Name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			if !assert.NoError((&planMutatingHook{}).Default(context.Background(), tCase.Plan), "Should add defaults to plan") {
+			if !assert.NoError((&planMutatingHook{}).Default(t.Context(), tCase.Plan), "Should add defaults to plan") {
 				t.FailNow()
 			}
 
@@ -263,7 +262,9 @@ func TestValidate(t *testing.T) {
 func TestValidateCreate(t *testing.T) {
 	assert := assert.New(t)
 
-	warn, err := (&planValidatingHook{}).ValidateCreate(context.Background(), &api.KubeUpgradePlan{})
+	ctx := t.Context()
+
+	warn, err := (&planValidatingHook{}).ValidateCreate(ctx, &api.KubeUpgradePlan{})
 
 	assert.Nil(warn, "Should not return a warning")
 	assert.Error(err, "Should return an error")
@@ -289,7 +290,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 	}
 
-	warn, err = (&planValidatingHook{}).ValidateCreate(context.Background(), plan)
+	warn, err = (&planValidatingHook{}).ValidateCreate(ctx, plan)
 
 	assert.Nil(warn, "Should not return a warning")
 	assert.NoError(err, "Should not return an error")
@@ -298,7 +299,9 @@ func TestValidateCreate(t *testing.T) {
 func TestValidateUpdate(t *testing.T) {
 	assert := assert.New(t)
 
-	warn, err := (&planValidatingHook{}).ValidateUpdate(context.Background(), &api.KubeUpgradePlan{}, &api.KubeUpgradePlan{})
+	ctx := t.Context()
+
+	warn, err := (&planValidatingHook{}).ValidateUpdate(ctx, &api.KubeUpgradePlan{}, &api.KubeUpgradePlan{})
 
 	assert.Nil(warn, "Should not return a warning")
 	assert.Error(err, "Should return an error")
@@ -324,7 +327,7 @@ func TestValidateUpdate(t *testing.T) {
 		},
 	}
 
-	warn, err = (&planValidatingHook{}).ValidateUpdate(context.Background(), &api.KubeUpgradePlan{}, plan)
+	warn, err = (&planValidatingHook{}).ValidateUpdate(ctx, &api.KubeUpgradePlan{}, plan)
 
 	assert.Nil(warn, "Should not return a warning")
 	assert.NoError(err, "Should not return an error")
@@ -333,7 +336,7 @@ func TestValidateUpdate(t *testing.T) {
 func TestValidateDelete(t *testing.T) {
 	assert := assert.New(t)
 
-	warn, err := (&planValidatingHook{}).ValidateDelete(context.Background(), nil)
+	warn, err := (&planValidatingHook{}).ValidateDelete(t.Context(), nil)
 
 	assert.Nil(warn, "Should not return a warning")
 	assert.NoError(err, "Should not return an error")

--- a/pkg/upgraded/daemon/config_test.go
+++ b/pkg/upgraded/daemon/config_test.go
@@ -21,7 +21,7 @@ func TestUpdateConfigFromNode(t *testing.T) {
 		t.FailNow()
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	t.Cleanup(cancel)
 
 	d := &daemon{
@@ -39,7 +39,7 @@ func TestUpdateConfigFromNode(t *testing.T) {
 			},
 		},
 	}
-	_, _ = d.client.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+	_, _ = d.client.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 
 	assert.NoError(d.UpdateConfigFromNode(), "Should succeed")
 	assert.Equal("registry.example.com/fcos-k8s", d.stream, "Should have updated stream")

--- a/pkg/upgraded/daemon/daemon_test.go
+++ b/pkg/upgraded/daemon/daemon_test.go
@@ -77,7 +77,7 @@ func TestNewDaemon(t *testing.T) {
 }
 
 func TestRetry(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	d := &daemon{
 		retryInterval: time.Millisecond,
 		ctx:           ctx,

--- a/pkg/upgraded/daemon/stream_test.go
+++ b/pkg/upgraded/daemon/stream_test.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -27,7 +26,7 @@ func TestDoUpgrade(t *testing.T) {
 				Name: d.node,
 			},
 		}
-		_, _ = d.client.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+		_, _ = d.client.CoreV1().Nodes().Create(t.Context(), node, metav1.CreateOptions{})
 
 		return d
 	}

--- a/pkg/upgraded/daemon/utils_test.go
+++ b/pkg/upgraded/daemon/utils_test.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"context"
 	"testing"
 
 	"github.com/heathcliff26/kube-upgrade/pkg/constants"
@@ -23,7 +22,7 @@ func TestFindNodeByListingAllNodes(t *testing.T) {
 			},
 		},
 	}
-	_, _ = client.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+	_, _ = client.CoreV1().Nodes().Create(t.Context(), node, metav1.CreateOptions{})
 
 	res, err := findNodeByListingAllNodes(client, "1234567890")
 


### PR DESCRIPTION
Use the context provided by testing instead of an generic background context.