### PR TITLE
Suppress code alerts found by gosec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,8 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    with:
+      args: "-exclude-generated ./..."
 
   unit-tests:
     uses: heathcliff26/ci/.github/workflows/golang-unit-tests.yaml@main

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ e2e:
 
 # Scan code for vulnerabilities using gosec
 gosec:
-	gosec ./...
+	gosec -exclude-generated ./...
 
 # Remove build artifacts and temporary files
 clean:

--- a/pkg/upgraded/config/config.go
+++ b/pkg/upgraded/config/config.go
@@ -78,6 +78,7 @@ func LoadConfig(path string) (*Config, error) {
 		p = DEFAULT_CONFIG_PATH
 	}
 
+	// #nosec G304: Local users can decide on their file path themselves.
 	f, err := os.ReadFile(p)
 	if os.IsNotExist(err) && path == "" {
 		slog.Info("No config file specified and default file does not exist, falling back to default values.", slog.String("default-path", DEFAULT_CONFIG_PATH))

--- a/pkg/upgraded/kubeadm/kubeadm.go
+++ b/pkg/upgraded/kubeadm/kubeadm.go
@@ -56,6 +56,7 @@ func (k *KubeadmCMD) Version() string {
 }
 
 func (k *KubeadmCMD) getVersion() (string, error) {
+	// #nosec G204: Binary path is controlled by the user
 	out, err := exec.Command(k.binary, "version", "--output", "short").Output()
 	if err != nil {
 		return "", err

--- a/pkg/upgraded/rpm-ostree/rpm-ostree.go
+++ b/pkg/upgraded/rpm-ostree/rpm-ostree.go
@@ -30,6 +30,7 @@ func (r *RPMOStreeCMD) CheckForUpgrade() (bool, error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
+	// #nosec G204: Binary path is controlled by the user
 	cmd := exec.Command(r.binary, "upgrade", "--check")
 	out, err := cmd.CombinedOutput()
 	code, ok := getExitCode(err)


### PR DESCRIPTION
Add #nosec comments with justification where appropiate.
Exclude generated code from gosec checks.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>