### PR TITLE
Makefile: Unpin controller-gen version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ coverprofile:
 	hack/coverprofile.sh
 
 # Run linter
-lint:
+lint: golangci-lint
 	golangci-lint run -v
 
 # Generate code and artifacts
@@ -63,9 +63,13 @@ gosec:
 clean:
 	rm -rf bin manifests/release coverprofiles coverprofile.out logs tmp_controller_image_kube-upgrade-e2e-*.tar
 
+# Install the golangci-lint tool
+golangci-lint:
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+
 # Install the controller-gen tool
 controller-gen:
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
 
 # Show this help message
 help:

--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -8,7 +8,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: kubeupgradeplans.kubeupgrade.heathcliff.eu
 spec:
   group: kubeupgrade.heathcliff.eu
@@ -77,11 +77,13 @@ spec:
                       nullable: true
                       properties:
                         check-interval:
+                          default: 3h
                           description: The interval between regular checks
                           example: 3h;24h;30m
                           format: duration
                           type: string
                         fleetlock-group:
+                          default: default
                           description: The group to use for fleetlock
                           example: control-plane;compute
                           type: string
@@ -91,12 +93,14 @@ spec:
                           example: https://fleetlock.example.com
                           type: string
                         retry-interval:
+                          default: 5m
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
                           format: duration
                           type: string
                         stream:
+                          default: ghcr.io/heathcliff26/fcos-k8s
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
                           type: string
@@ -122,11 +126,13 @@ spec:
                 nullable: true
                 properties:
                   check-interval:
+                    default: 3h
                     description: The interval between regular checks
                     example: 3h;24h;30m
                     format: duration
                     type: string
                   fleetlock-group:
+                    default: default
                     description: The group to use for fleetlock
                     example: control-plane;compute
                     type: string
@@ -136,11 +142,13 @@ spec:
                     example: https://fleetlock.example.com
                     type: string
                   retry-interval:
+                    default: 5m
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
                     format: duration
                     type: string
                   stream:
+                    default: ghcr.io/heathcliff26/fcos-k8s
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s
                     type: string
@@ -205,6 +213,7 @@ spec:
           spec:
             properties:
               allowDowngrade:
+                default: false
                 description: |-
                   Allow downgrading to older kubernetes versions.
                   Only enable if you know what you are doing.
@@ -275,11 +284,13 @@ spec:
                       nullable: true
                       properties:
                         check-interval:
+                          default: 3h
                           description: The interval between regular checks
                           example: 3h;24h;30m
                           format: go-duration
                           type: string
                         fleetlock-group:
+                          default: default
                           description: The group to use for fleetlock
                           example: control-plane;compute
                           type: string
@@ -289,12 +300,14 @@ spec:
                           example: https://fleetlock.example.com
                           type: string
                         retry-interval:
+                          default: 5m
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
                           format: go-duration
                           type: string
                         stream:
+                          default: ghcr.io/heathcliff26/fcos-k8s
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
                           type: string
@@ -319,11 +332,13 @@ spec:
                   by group specific config.
                 properties:
                   check-interval:
+                    default: 3h
                     description: The interval between regular checks
                     example: 3h;24h;30m
                     format: go-duration
                     type: string
                   fleetlock-group:
+                    default: default
                     description: The group to use for fleetlock
                     example: control-plane;compute
                     type: string
@@ -333,11 +348,13 @@ spec:
                     example: https://fleetlock.example.com
                     type: string
                   retry-interval:
+                    default: 5m
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
                     format: go-duration
                     type: string
                   stream:
+                    default: ghcr.io/heathcliff26/fcos-k8s
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s
                     type: string
@@ -345,6 +362,7 @@ spec:
             required:
             - groups
             - kubernetesVersion
+            - upgraded
             type: object
           status:
             properties:

--- a/examples/upgrade-controller/upgrade-cr.yaml
+++ b/examples/upgrade-controller/upgrade-cr.yaml
@@ -5,7 +5,7 @@ kind: KubeUpgradePlan
 metadata:
   name: upgrade-plan
 spec:
-  kubernetesVersion: v1.31.1
+  kubernetesVersion: v1.33.0
   upgraded:
     fleetlock-url: https://fleetlock.example.com
   groups:

--- a/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
+++ b/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: kubeupgradeplans.kubeupgrade.heathcliff.eu
 spec:
   group: kubeupgrade.heathcliff.eu
@@ -72,11 +72,13 @@ spec:
                       nullable: true
                       properties:
                         check-interval:
+                          default: 3h
                           description: The interval between regular checks
                           example: 3h;24h;30m
                           format: duration
                           type: string
                         fleetlock-group:
+                          default: default
                           description: The group to use for fleetlock
                           example: control-plane;compute
                           type: string
@@ -86,12 +88,14 @@ spec:
                           example: https://fleetlock.example.com
                           type: string
                         retry-interval:
+                          default: 5m
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
                           format: duration
                           type: string
                         stream:
+                          default: ghcr.io/heathcliff26/fcos-k8s
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
                           type: string
@@ -117,11 +121,13 @@ spec:
                 nullable: true
                 properties:
                   check-interval:
+                    default: 3h
                     description: The interval between regular checks
                     example: 3h;24h;30m
                     format: duration
                     type: string
                   fleetlock-group:
+                    default: default
                     description: The group to use for fleetlock
                     example: control-plane;compute
                     type: string
@@ -131,11 +137,13 @@ spec:
                     example: https://fleetlock.example.com
                     type: string
                   retry-interval:
+                    default: 5m
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
                     format: duration
                     type: string
                   stream:
+                    default: ghcr.io/heathcliff26/fcos-k8s
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s
                     type: string
@@ -200,6 +208,7 @@ spec:
           spec:
             properties:
               allowDowngrade:
+                default: false
                 description: |-
                   Allow downgrading to older kubernetes versions.
                   Only enable if you know what you are doing.
@@ -270,11 +279,13 @@ spec:
                       nullable: true
                       properties:
                         check-interval:
+                          default: 3h
                           description: The interval between regular checks
                           example: 3h;24h;30m
                           format: go-duration
                           type: string
                         fleetlock-group:
+                          default: default
                           description: The group to use for fleetlock
                           example: control-plane;compute
                           type: string
@@ -284,12 +295,14 @@ spec:
                           example: https://fleetlock.example.com
                           type: string
                         retry-interval:
+                          default: 5m
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
                           format: go-duration
                           type: string
                         stream:
+                          default: ghcr.io/heathcliff26/fcos-k8s
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
                           type: string
@@ -314,11 +327,13 @@ spec:
                   by group specific config.
                 properties:
                   check-interval:
+                    default: 3h
                     description: The interval between regular checks
                     example: 3h;24h;30m
                     format: go-duration
                     type: string
                   fleetlock-group:
+                    default: default
                     description: The group to use for fleetlock
                     example: control-plane;compute
                     type: string
@@ -328,11 +343,13 @@ spec:
                     example: https://fleetlock.example.com
                     type: string
                   retry-interval:
+                    default: 5m
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
                     format: go-duration
                     type: string
                   stream:
+                    default: ghcr.io/heathcliff26/fcos-k8s
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s
                     type: string
@@ -340,6 +357,7 @@ spec:
             required:
             - groups
             - kubernetesVersion
+            - upgraded
             type: object
           status:
             properties:

--- a/manifests/generated/kubeupgradeplan_v1alpha1.json
+++ b/manifests/generated/kubeupgradeplan_v1alpha1.json
@@ -38,12 +38,14 @@
                 "nullable": true,
                 "properties": {
                   "check-interval": {
+                    "default": "3h",
                     "description": "The interval between regular checks",
                     "example": "3h;24h;30m",
                     "format": "duration",
                     "type": "string"
                   },
                   "fleetlock-group": {
+                    "default": "default",
                     "description": "The group to use for fleetlock",
                     "example": "control-plane;compute",
                     "type": "string"
@@ -54,12 +56,14 @@
                     "type": "string"
                   },
                   "retry-interval": {
+                    "default": "5m",
                     "description": "The interval between retries when an operation fails",
                     "example": "5m;1m;30s",
                     "format": "duration",
                     "type": "string"
                   },
                   "stream": {
+                    "default": "ghcr.io/heathcliff26/fcos-k8s",
                     "description": "The container image repository for os rebases",
                     "example": "ghcr.io/heathcliff26/fcos-k8s",
                     "type": "string"
@@ -90,12 +94,14 @@
           "nullable": true,
           "properties": {
             "check-interval": {
+              "default": "3h",
               "description": "The interval between regular checks",
               "example": "3h;24h;30m",
               "format": "duration",
               "type": "string"
             },
             "fleetlock-group": {
+              "default": "default",
               "description": "The group to use for fleetlock",
               "example": "control-plane;compute",
               "type": "string"
@@ -106,12 +112,14 @@
               "type": "string"
             },
             "retry-interval": {
+              "default": "5m",
               "description": "The interval between retries when an operation fails",
               "example": "5m;1m;30s",
               "format": "duration",
               "type": "string"
             },
             "stream": {
+              "default": "ghcr.io/heathcliff26/fcos-k8s",
               "description": "The container image repository for os rebases",
               "example": "ghcr.io/heathcliff26/fcos-k8s",
               "type": "string"

--- a/manifests/generated/kubeupgradeplan_v1alpha2.json
+++ b/manifests/generated/kubeupgradeplan_v1alpha2.json
@@ -14,6 +14,7 @@
     "spec": {
       "properties": {
         "allowDowngrade": {
+          "default": false,
           "description": "Allow downgrading to older kubernetes versions.\nOnly enable if you know what you are doing.",
           "type": "boolean"
         },
@@ -82,12 +83,14 @@
                 "nullable": true,
                 "properties": {
                   "check-interval": {
+                    "default": "3h",
                     "description": "The interval between regular checks",
                     "example": "3h;24h;30m",
                     "format": "go-duration",
                     "type": "string"
                   },
                   "fleetlock-group": {
+                    "default": "default",
                     "description": "The group to use for fleetlock",
                     "example": "control-plane;compute",
                     "type": "string"
@@ -98,12 +101,14 @@
                     "type": "string"
                   },
                   "retry-interval": {
+                    "default": "5m",
                     "description": "The interval between retries when an operation fails",
                     "example": "5m;1m;30s",
                     "format": "go-duration",
                     "type": "string"
                   },
                   "stream": {
+                    "default": "ghcr.io/heathcliff26/fcos-k8s",
                     "description": "The container image repository for os rebases",
                     "example": "ghcr.io/heathcliff26/fcos-k8s",
                     "type": "string"
@@ -133,12 +138,14 @@
           "description": "The configuration for all upgraded daemons. Can be overwritten by group specific config.",
           "properties": {
             "check-interval": {
+              "default": "3h",
               "description": "The interval between regular checks",
               "example": "3h;24h;30m",
               "format": "go-duration",
               "type": "string"
             },
             "fleetlock-group": {
+              "default": "default",
               "description": "The group to use for fleetlock",
               "example": "control-plane;compute",
               "type": "string"
@@ -149,12 +156,14 @@
               "type": "string"
             },
             "retry-interval": {
+              "default": "5m",
               "description": "The interval between retries when an operation fails",
               "example": "5m;1m;30s",
               "format": "go-duration",
               "type": "string"
             },
             "stream": {
+              "default": "ghcr.io/heathcliff26/fcos-k8s",
               "description": "The container image repository for os rebases",
               "example": "ghcr.io/heathcliff26/fcos-k8s",
               "type": "string"
@@ -166,7 +175,8 @@
       },
       "required": [
         "groups",
-        "kubernetesVersion"
+        "kubernetesVersion",
+        "upgraded"
       ],
       "type": "object",
       "additionalProperties": false


### PR DESCRIPTION
Always use latest controller-gen.
Add install command for golangci-lint.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>