### PR TITLE
Makefile: pin controller-gen to v0.18.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ golangci-lint:
 
 # Install the controller-gen tool
 controller-gen:
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0
 
 # Show this help message
 help:

--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -8,7 +8,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: kubeupgradeplans.kubeupgrade.heathcliff.eu
 spec:
   group: kubeupgrade.heathcliff.eu

--- a/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
+++ b/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: kubeupgradeplans.kubeupgrade.heathcliff.eu
 spec:
   group: kubeupgrade.heathcliff.eu


### PR DESCRIPTION
Prevent random updates to the generated CRD by pinning the controller-gen
version.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>