### PR TITLE
hack/validate.sh: Skip kubeconform

### DIFF
--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -44,4 +44,5 @@ fi
 git checkout examples/upgrade-controller/upgrade-cr.yaml
 
 echo "Check if the generated example plan is conform"
-kubeconform -schema-location manifests/generated/kubeupgradeplan_v1alpha2.json -verbose -strict examples/upgrade-controller/upgrade-cr.yaml
+#kubeconform -schema-location manifests/generated/kubeupgradeplan_v1alpha2.json -verbose -strict examples/upgrade-controller/upgrade-cr.yaml
+echo "skipping kubeconform. Check if it is correctly managing semver again"


### PR DESCRIPTION
Currently kubeconform errors on semver fields when they start with a "v", like kubernetes versions do.

See: https://github.com/yannh/kubeconform/issues/331