### PR TITLE
api: Remove semver validation for kubernetes version

### DIFF
--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -325,7 +325,6 @@ spec:
                   The kubernetes version the cluster should be at.
                   If the actual version differs, the cluster will be upgraded.
                 example: v1.31.0
-                format: semver
                 type: string
               upgraded:
                 description: The configuration for all upgraded daemons. Can be overwritten

--- a/examples/upgrade-controller/upgrade-cr.yaml
+++ b/examples/upgrade-controller/upgrade-cr.yaml
@@ -5,7 +5,7 @@ kind: KubeUpgradePlan
 metadata:
   name: upgrade-plan
 spec:
-  kubernetesVersion: v1.33.0
+  kubernetesVersion: v1.33.2
   upgraded:
     fleetlock-url: https://fleetlock.example.com
   groups:

--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -53,5 +53,4 @@ fi
 git checkout examples/upgrade-controller/upgrade-cr.yaml
 
 echo "Check if the generated example plan is conform"
-#kubeconform -schema-location manifests/generated/kubeupgradeplan_v1alpha2.json -verbose -strict examples/upgrade-controller/upgrade-cr.yaml
-echo "skipping kubeconform. Check if it is correctly managing semver again"
+kubeconform -schema-location manifests/generated/kubeupgradeplan_v1alpha2.json -verbose -strict examples/upgrade-controller/upgrade-cr.yaml

--- a/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
+++ b/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
@@ -320,7 +320,6 @@ spec:
                   The kubernetes version the cluster should be at.
                   If the actual version differs, the cluster will be upgraded.
                 example: v1.31.0
-                format: semver
                 type: string
               upgraded:
                 description: The configuration for all upgraded daemons. Can be overwritten

--- a/manifests/generated/kubeupgradeplan_v1alpha2.json
+++ b/manifests/generated/kubeupgradeplan_v1alpha2.json
@@ -131,7 +131,6 @@
         "kubernetesVersion": {
           "description": "The kubernetes version the cluster should be at.\nIf the actual version differs, the cluster will be upgraded.",
           "example": "v1.31.0",
-          "format": "semver",
           "type": "string"
         },
         "upgraded": {

--- a/pkg/apis/kubeupgrade/v1alpha2/types.go
+++ b/pkg/apis/kubeupgrade/v1alpha2/types.go
@@ -36,7 +36,6 @@ type KubeUpgradeSpec struct {
 	// The kubernetes version the cluster should be at.
 	// If the actual version differs, the cluster will be upgraded.
 	// +required
-	// +kubebuilder:validation:Format=semver
 	// +kubebuilder:example=v1.31.0
 	KubernetesVersion string `json:"kubernetesVersion"`
 


### PR DESCRIPTION
Kubernetes versions start with "v", which means that kubeconform now no longer
accepts them as valid semver versions.
See: https://github.com/yannh/kubeconform/issues/331

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>