### PR TITLE
upgrade-controller: Fix empty group upgraded settings set to default

### DIFF
--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -77,13 +77,11 @@ spec:
                       nullable: true
                       properties:
                         check-interval:
-                          default: 3h
                           description: The interval between regular checks
                           example: 3h;24h;30m
                           format: duration
                           type: string
                         fleetlock-group:
-                          default: default
                           description: The group to use for fleetlock
                           example: control-plane;compute
                           type: string
@@ -93,14 +91,12 @@ spec:
                           example: https://fleetlock.example.com
                           type: string
                         retry-interval:
-                          default: 5m
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
                           format: duration
                           type: string
                         stream:
-                          default: ghcr.io/heathcliff26/fcos-k8s
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
                           type: string
@@ -126,13 +122,11 @@ spec:
                 nullable: true
                 properties:
                   check-interval:
-                    default: 3h
                     description: The interval between regular checks
                     example: 3h;24h;30m
                     format: duration
                     type: string
                   fleetlock-group:
-                    default: default
                     description: The group to use for fleetlock
                     example: control-plane;compute
                     type: string
@@ -142,13 +136,11 @@ spec:
                     example: https://fleetlock.example.com
                     type: string
                   retry-interval:
-                    default: 5m
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
                     format: duration
                     type: string
                   stream:
-                    default: ghcr.io/heathcliff26/fcos-k8s
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s
                     type: string
@@ -284,13 +276,11 @@ spec:
                       nullable: true
                       properties:
                         check-interval:
-                          default: 3h
                           description: The interval between regular checks
                           example: 3h;24h;30m
                           format: go-duration
                           type: string
                         fleetlock-group:
-                          default: default
                           description: The group to use for fleetlock
                           example: control-plane;compute
                           type: string
@@ -300,14 +290,12 @@ spec:
                           example: https://fleetlock.example.com
                           type: string
                         retry-interval:
-                          default: 5m
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
                           format: go-duration
                           type: string
                         stream:
-                          default: ghcr.io/heathcliff26/fcos-k8s
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
                           type: string
@@ -331,13 +319,11 @@ spec:
                   by group specific config.
                 properties:
                   check-interval:
-                    default: 3h
                     description: The interval between regular checks
                     example: 3h;24h;30m
                     format: go-duration
                     type: string
                   fleetlock-group:
-                    default: default
                     description: The group to use for fleetlock
                     example: control-plane;compute
                     type: string
@@ -347,13 +333,11 @@ spec:
                     example: https://fleetlock.example.com
                     type: string
                   retry-interval:
-                    default: 5m
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
                     format: go-duration
                     type: string
                   stream:
-                    default: ghcr.io/heathcliff26/fcos-k8s
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s
                     type: string

--- a/examples/upgrade-controller/upgrade-cr.yaml
+++ b/examples/upgrade-controller/upgrade-cr.yaml
@@ -5,7 +5,7 @@ kind: KubeUpgradePlan
 metadata:
   name: upgrade-plan
 spec:
-  kubernetesVersion: v1.33.2
+  kubernetesVersion: v1.34.1
   upgraded:
     fleetlock-url: https://fleetlock.example.com
   groups:

--- a/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
+++ b/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
@@ -72,13 +72,11 @@ spec:
                       nullable: true
                       properties:
                         check-interval:
-                          default: 3h
                           description: The interval between regular checks
                           example: 3h;24h;30m
                           format: duration
                           type: string
                         fleetlock-group:
-                          default: default
                           description: The group to use for fleetlock
                           example: control-plane;compute
                           type: string
@@ -88,14 +86,12 @@ spec:
                           example: https://fleetlock.example.com
                           type: string
                         retry-interval:
-                          default: 5m
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
                           format: duration
                           type: string
                         stream:
-                          default: ghcr.io/heathcliff26/fcos-k8s
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
                           type: string
@@ -121,13 +117,11 @@ spec:
                 nullable: true
                 properties:
                   check-interval:
-                    default: 3h
                     description: The interval between regular checks
                     example: 3h;24h;30m
                     format: duration
                     type: string
                   fleetlock-group:
-                    default: default
                     description: The group to use for fleetlock
                     example: control-plane;compute
                     type: string
@@ -137,13 +131,11 @@ spec:
                     example: https://fleetlock.example.com
                     type: string
                   retry-interval:
-                    default: 5m
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
                     format: duration
                     type: string
                   stream:
-                    default: ghcr.io/heathcliff26/fcos-k8s
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s
                     type: string
@@ -279,13 +271,11 @@ spec:
                       nullable: true
                       properties:
                         check-interval:
-                          default: 3h
                           description: The interval between regular checks
                           example: 3h;24h;30m
                           format: go-duration
                           type: string
                         fleetlock-group:
-                          default: default
                           description: The group to use for fleetlock
                           example: control-plane;compute
                           type: string
@@ -295,14 +285,12 @@ spec:
                           example: https://fleetlock.example.com
                           type: string
                         retry-interval:
-                          default: 5m
                           description: The interval between retries when an operation
                             fails
                           example: 5m;1m;30s
                           format: go-duration
                           type: string
                         stream:
-                          default: ghcr.io/heathcliff26/fcos-k8s
                           description: The container image repository for os rebases
                           example: ghcr.io/heathcliff26/fcos-k8s
                           type: string
@@ -326,13 +314,11 @@ spec:
                   by group specific config.
                 properties:
                   check-interval:
-                    default: 3h
                     description: The interval between regular checks
                     example: 3h;24h;30m
                     format: go-duration
                     type: string
                   fleetlock-group:
-                    default: default
                     description: The group to use for fleetlock
                     example: control-plane;compute
                     type: string
@@ -342,13 +328,11 @@ spec:
                     example: https://fleetlock.example.com
                     type: string
                   retry-interval:
-                    default: 5m
                     description: The interval between retries when an operation fails
                     example: 5m;1m;30s
                     format: go-duration
                     type: string
                   stream:
-                    default: ghcr.io/heathcliff26/fcos-k8s
                     description: The container image repository for os rebases
                     example: ghcr.io/heathcliff26/fcos-k8s
                     type: string

--- a/manifests/generated/kubeupgradeplan_v1alpha1.json
+++ b/manifests/generated/kubeupgradeplan_v1alpha1.json
@@ -38,14 +38,12 @@
                 "nullable": true,
                 "properties": {
                   "check-interval": {
-                    "default": "3h",
                     "description": "The interval between regular checks",
                     "example": "3h;24h;30m",
                     "format": "duration",
                     "type": "string"
                   },
                   "fleetlock-group": {
-                    "default": "default",
                     "description": "The group to use for fleetlock",
                     "example": "control-plane;compute",
                     "type": "string"
@@ -56,14 +54,12 @@
                     "type": "string"
                   },
                   "retry-interval": {
-                    "default": "5m",
                     "description": "The interval between retries when an operation fails",
                     "example": "5m;1m;30s",
                     "format": "duration",
                     "type": "string"
                   },
                   "stream": {
-                    "default": "ghcr.io/heathcliff26/fcos-k8s",
                     "description": "The container image repository for os rebases",
                     "example": "ghcr.io/heathcliff26/fcos-k8s",
                     "type": "string"
@@ -94,14 +90,12 @@
           "nullable": true,
           "properties": {
             "check-interval": {
-              "default": "3h",
               "description": "The interval between regular checks",
               "example": "3h;24h;30m",
               "format": "duration",
               "type": "string"
             },
             "fleetlock-group": {
-              "default": "default",
               "description": "The group to use for fleetlock",
               "example": "control-plane;compute",
               "type": "string"
@@ -112,14 +106,12 @@
               "type": "string"
             },
             "retry-interval": {
-              "default": "5m",
               "description": "The interval between retries when an operation fails",
               "example": "5m;1m;30s",
               "format": "duration",
               "type": "string"
             },
             "stream": {
-              "default": "ghcr.io/heathcliff26/fcos-k8s",
               "description": "The container image repository for os rebases",
               "example": "ghcr.io/heathcliff26/fcos-k8s",
               "type": "string"

--- a/manifests/generated/kubeupgradeplan_v1alpha2.json
+++ b/manifests/generated/kubeupgradeplan_v1alpha2.json
@@ -83,14 +83,12 @@
                 "nullable": true,
                 "properties": {
                   "check-interval": {
-                    "default": "3h",
                     "description": "The interval between regular checks",
                     "example": "3h;24h;30m",
                     "format": "go-duration",
                     "type": "string"
                   },
                   "fleetlock-group": {
-                    "default": "default",
                     "description": "The group to use for fleetlock",
                     "example": "control-plane;compute",
                     "type": "string"
@@ -101,14 +99,12 @@
                     "type": "string"
                   },
                   "retry-interval": {
-                    "default": "5m",
                     "description": "The interval between retries when an operation fails",
                     "example": "5m;1m;30s",
                     "format": "go-duration",
                     "type": "string"
                   },
                   "stream": {
-                    "default": "ghcr.io/heathcliff26/fcos-k8s",
                     "description": "The container image repository for os rebases",
                     "example": "ghcr.io/heathcliff26/fcos-k8s",
                     "type": "string"
@@ -137,14 +133,12 @@
           "description": "The configuration for all upgraded daemons. Can be overwritten by group specific config.",
           "properties": {
             "check-interval": {
-              "default": "3h",
               "description": "The interval between regular checks",
               "example": "3h;24h;30m",
               "format": "go-duration",
               "type": "string"
             },
             "fleetlock-group": {
-              "default": "default",
               "description": "The group to use for fleetlock",
               "example": "control-plane;compute",
               "type": "string"
@@ -155,14 +149,12 @@
               "type": "string"
             },
             "retry-interval": {
-              "default": "5m",
               "description": "The interval between retries when an operation fails",
               "example": "5m;1m;30s",
               "format": "go-duration",
               "type": "string"
             },
             "stream": {
-              "default": "ghcr.io/heathcliff26/fcos-k8s",
               "description": "The container image repository for os rebases",
               "example": "ghcr.io/heathcliff26/fcos-k8s",
               "type": "string"

--- a/pkg/apis/kubeupgrade/v1alpha1/types.go
+++ b/pkg/apis/kubeupgrade/v1alpha1/types.go
@@ -81,7 +81,6 @@ type KubeUpgradeStatus struct {
 type UpgradedConfig struct {
 	// The container image repository for os rebases
 	// +optional
-	// +default="ghcr.io/heathcliff26/fcos-k8s"
 	// +kubebuilder:example="ghcr.io/heathcliff26/fcos-k8s"
 	Stream string `json:"stream,omitempty"`
 
@@ -91,21 +90,18 @@ type UpgradedConfig struct {
 	FleetlockURL string `json:"fleetlock-url"`
 
 	// The group to use for fleetlock
-	// +default="default"
 	// +kubebuilder:example="control-plane;compute"
 	FleetlockGroup string `json:"fleetlock-group,omitempty"`
 
 	// The interval between regular checks
 	// +optional
 	// +kubebuilder:validation:Format=duration
-	// +default="3h"
 	// +kubebuilder:example="3h;24h;30m"
 	CheckInterval string `json:"check-interval,omitempty"`
 
 	// The interval between retries when an operation fails
 	// +optional
 	// +kubebuilder:validation:Format=duration
-	// +default="5m"
 	// +kubebuilder:example="5m;1m;30s"
 	RetryInterval string `json:"retry-interval,omitempty"`
 }

--- a/pkg/apis/kubeupgrade/v1alpha2/types.go
+++ b/pkg/apis/kubeupgrade/v1alpha2/types.go
@@ -86,7 +86,6 @@ type KubeUpgradeStatus struct {
 type UpgradedConfig struct {
 	// The container image repository for os rebases
 	// +optional
-	// +default="ghcr.io/heathcliff26/fcos-k8s"
 	// +kubebuilder:example="ghcr.io/heathcliff26/fcos-k8s"
 	Stream string `json:"stream,omitempty"`
 
@@ -96,21 +95,18 @@ type UpgradedConfig struct {
 	FleetlockURL string `json:"fleetlock-url"`
 
 	// The group to use for fleetlock
-	// +default="default"
 	// +kubebuilder:example="control-plane;compute"
 	FleetlockGroup string `json:"fleetlock-group,omitempty"`
 
 	// The interval between regular checks
 	// +optional
 	// +kubebuilder:validation:Format=go-duration
-	// +default="3h"
 	// +kubebuilder:example="3h;24h;30m"
 	CheckInterval string `json:"check-interval,omitempty"`
 
 	// The interval between retries when an operation fails
 	// +optional
 	// +kubebuilder:validation:Format=go-duration
-	// +default="5m"
 	// +kubebuilder:example="5m;1m;30s"
 	RetryInterval string `json:"retry-interval,omitempty"`
 }

--- a/tests/e2e_suite_test.go
+++ b/tests/e2e_suite_test.go
@@ -233,6 +233,11 @@ func TestE2E(t *testing.T) {
 			assert.Equal(api.DefaultUpgradedCheckInterval, plan.Spec.Upgraded.CheckInterval, "Should set default upgraded check-interval")
 			assert.Equal(api.DefaultUpgradedRetryInterval, plan.Spec.Upgraded.RetryInterval, "Should set default upgraded retry-interval")
 
+			assert.Empty(plan.Spec.Groups["control-plane"].Upgraded.Stream, "Should leave group upgraded stream empty")
+			assert.Equal("control-plane", plan.Spec.Groups["control-plane"].Upgraded.FleetlockGroup, "Should set fleetlock group for control-plane")
+			assert.Empty(plan.Spec.Groups["control-plane"].Upgraded.CheckInterval, "Should leave group upgraded check-interval empty")
+			assert.Empty(plan.Spec.Groups["control-plane"].Upgraded.RetryInterval, "Should leave group upgraded retry-interval empty")
+
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {


### PR DESCRIPTION
Stop group settings from being set to default values when left empty.
This would cause the global settings to be overwritten with defaults,
effectively making them useless.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>