### PR TITLE
upgraded: Decrease default retry interval to 1m

### DIFF
--- a/pkg/apis/kubeupgrade/v1alpha2/defaults.go
+++ b/pkg/apis/kubeupgrade/v1alpha2/defaults.go
@@ -7,7 +7,7 @@ const (
 	DefaultUpgradedStream         = "ghcr.io/heathcliff26/fcos-k8s"
 	DefaultUpgradedFleetlockGroup = "default"
 	DefaultUpgradedCheckInterval  = "3h"
-	DefaultUpgradedRetryInterval  = "5m"
+	DefaultUpgradedRetryInterval  = "1m"
 )
 
 func SetObjectDefaults_KubeUpgradeSpec(spec *KubeUpgradeSpec) {
@@ -25,15 +25,15 @@ func SetObjectDefaults_KubeUpgradeSpec(spec *KubeUpgradeSpec) {
 
 func SetObjectDefaults_UpgradedConfig(cfg *UpgradedConfig) {
 	if cfg.Stream == "" {
-		cfg.Stream = "ghcr.io/heathcliff26/fcos-k8s"
+		cfg.Stream = DefaultUpgradedStream
 	}
 	if cfg.FleetlockGroup == "" {
-		cfg.FleetlockGroup = "default"
+		cfg.FleetlockGroup = DefaultUpgradedFleetlockGroup
 	}
 	if cfg.CheckInterval == "" {
-		cfg.CheckInterval = "3h"
+		cfg.CheckInterval = DefaultUpgradedCheckInterval
 	}
 	if cfg.RetryInterval == "" {
-		cfg.RetryInterval = "5m"
+		cfg.RetryInterval = DefaultUpgradedRetryInterval
 	}
 }

--- a/pkg/upgraded/daemon/daemon.go
+++ b/pkg/upgraded/daemon/daemon.go
@@ -23,7 +23,7 @@ const (
 	defaultStream         = "ghcr.io/heathcliff26/fcos-k8s"
 	defaultFleetlockGroup = "default"
 	defaultCheckInterval  = 3 * time.Hour
-	defaultRetryInterval  = 5 * time.Minute
+	defaultRetryInterval  = 1 * time.Minute
 )
 
 type daemon struct {


### PR DESCRIPTION
By default the retry interval on failure should be lower, to make upgrades wait less on waiting on example node drains.

Additionally ensure the defaults are set from the constants.