### PR TITLE
upgraded: Run upgraded as daemonset instead of on the host directly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,25 +90,18 @@ jobs:
       cmd: "make e2e"
 
   build-daemon:
-    uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
+    uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
+    needs:
+      - e2e
     permissions:
       contents: read
-    needs:
-      - lint
-      - unit-tests
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-          - arch: arm64
+      packages: write
     with:
-      release: "${{ github.event_name == 'pull_request' && 'dev' || inputs.tag == '' && 'rolling' || inputs.tag }}"
-      goos: "linux"
-      goarch: "${{ matrix.arch }}"
-      artifact: "bin/upgraded-${{ matrix.arch }}"
-      artifact-name: "upgraded-${{ matrix.arch }}"
-      cmd: "hack/build.sh upgraded upgraded-${{ matrix.arch }}"
+      app: kube-upgraded
+      dockerfile: cmd/upgraded/Dockerfile
+      tag: "${{ inputs.tag == '' && 'rolling' || inputs.tag }}"
+      tags: "${{ inputs.latest == true && 'type=raw,value=latest' || '' }}"
+      dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
     secrets: inherit
 
   build-controller:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,5 +57,5 @@ jobs:
       update: ${{ inputs.update }}
       tag: ${{ inputs.tag }}
       release-artifacts: "release/*"
-      artifacts: "{upgraded-*,manifests}"
+      artifacts: "manifests"
       prerelease: ${{ inputs.prerelease }}

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,27 @@ SHELL := bash
 REPOSITORY ?= ghcr.io/heathcliff26
 TAG ?= latest
 
-default: upgraded upgrade-controller
+# Build all images
+build: build-upgraded build-upgrade-controller
 
-# Build the upgraded binary
-upgraded:
-	hack/build.sh upgraded
+# Build the upgraded container image
+build-upgraded:
+	podman build -t $(REPOSITORY)/kube-upgraded:$(TAG) -f cmd/upgraded/Dockerfile .
 
 # Build the upgrade controller container image
-upgrade-controller:
+build-upgrade-controller:
 	podman build -t $(REPOSITORY)/kube-upgrade-controller:$(TAG) -f cmd/upgrade-controller/Dockerfile .
+
+# Build and push all images
+push: push-upgraded push-upgrade-controller
+
+# Build and push upgraded container image
+push-upgraded: build-upgraded
+	podman push $(REPOSITORY)/kube-upgraded:$(TAG)
+
+# Build and push upgrade controller container image
+push-upgrade-controller: build-upgrade-controller
+	podman push $(REPOSITORY)/kube-upgrade-controller:$(TAG)
 
 # Run unit-tests
 test:
@@ -80,9 +92,12 @@ help:
 	@echo "Run 'make <target>' to execute a specific target."
 
 .PHONY: \
-	default \
-	upgraded \
-	upgrade-controller \
+	build \
+	build-upgraded \
+	build-upgrade-controller \
+	push \
+	push-upgraded \
+	push-upgrade-controller \
 	test \
 	update-deps \
 	update-external-scripts \

--- a/cmd/upgraded/Dockerfile
+++ b/cmd/upgraded/Dockerfile
@@ -1,0 +1,40 @@
+###############################################################################
+# BEGIN build-stage
+# Compile the binary
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25.3 AS build-stage
+
+ARG BUILDPLATFORM
+ARG TARGETARCH
+
+WORKDIR /app
+
+COPY . ./
+
+RUN GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh upgraded
+
+#
+# END build-stage
+###############################################################################
+
+###############################################################################
+# BEGIN final-stage
+# Create final docker image
+FROM quay.io/fedora/fedora:43 AS final-stage
+
+# Force systemd to connect via the system dbus socket, instead of PID 1 socket
+ENV SYSTEMCTL_FORCE_BUS=1
+
+RUN dnf install -y --setopt=install_weak_deps=False \
+        rpm-ostree \
+        hostname && \
+    dnf clean -y all
+
+WORKDIR /
+
+COPY --from=build-stage /app/bin/upgraded /app/cmd/upgraded/start-upgraded.sh /
+
+ENTRYPOINT ["/start-upgraded.sh"]
+
+#
+# END final-stage
+###############################################################################

--- a/cmd/upgraded/start-upgraded.sh
+++ b/cmd/upgraded/start-upgraded.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Bind mount the container resolv.conf to prevent issues with systemd-resolved when running kubeadm in chroot
+mount --bind /etc/resolv.conf /host/etc/resolv.conf
+
+# Set the hostname in the pod to the node name.
+# This is needed for kubeadm, as it otherwise fails to find the node name.
+if [ -z "${HOSTNAME}" ]; then
+    echo "Error: HOSTNAME environment variable is empty. It needs to be set to the node name."
+    exit 1
+fi
+hostname "${HOSTNAME}"
+
+# shellcheck disable=SC2068
+/upgraded $@

--- a/examples/upgrade-controller/upgrade-controller.yaml
+++ b/examples/upgrade-controller/upgrade-controller.yaml
@@ -374,6 +374,8 @@ kind: ServiceAccount
 metadata:
   name: upgrade-controller
   namespace: kube-upgrade
+  labels:
+    app: upgrade-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -413,6 +415,8 @@ kind: ClusterRoleBinding
 metadata:
   name: upgrade-controller
   namespace: kube-upgrade
+  labels:
+    app: upgrade-controller
 subjects:
   - kind: ServiceAccount
     name: upgrade-controller
@@ -427,6 +431,8 @@ kind: Role
 metadata:
   name: upgrade-controller
   namespace: kube-upgrade
+  labels:
+    app: upgrade-controller
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -453,6 +459,8 @@ kind: Issuer
 metadata:
   name: selfsigned
   namespace: kube-upgrade
+  labels:
+    app: upgrade-controller
 spec:
   selfSigned: {}
 ---
@@ -461,6 +469,8 @@ kind: Certificate
 metadata:
   name: webhook-server-cert
   namespace: kube-upgrade
+  labels:
+    app: upgrade-controller
 spec:
   dnsNames:
   - upgrade-controller-webhooks.kube-upgrade.svc
@@ -532,16 +542,16 @@ metadata:
   name: upgrade-controller
   namespace: kube-upgrade
   labels:
-    app: kube-upgrade
+    app: upgrade-controller
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: kube-upgrade
+      app: upgrade-controller
   template:
     metadata:
       labels:
-        app: kube-upgrade
+        app: upgrade-controller
     spec:
       serviceAccountName: upgrade-controller
       containers:
@@ -589,11 +599,11 @@ metadata:
   name: upgrade-controller-webhooks
   namespace: kube-upgrade
   labels:
-    app: kube-upgrade
+    app: upgrade-controller
 spec:
   ports:
     - port: 443
       protocol: TCP
       targetPort: 9443
   selector:
-    app: kube-upgrade
+    app: upgrade-controller

--- a/examples/upgrade-controller/upgrade-cr.yaml
+++ b/examples/upgrade-controller/upgrade-cr.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kubernetesVersion: v1.34.1
   upgraded:
-    fleetlock-url: https://fleetlock.example.com
+    fleetlock-url: http://fleetlock.kube-upgrade.svc.cluster.local
   groups:
     control-plane:
       labels:

--- a/examples/upgrade-controller/upgraded-daemonset.yaml
+++ b/examples/upgrade-controller/upgraded-daemonset.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: upgraded
+  namespace: kube-upgrade
+  labels:
+    app: upgraded
+spec:
+  selector:
+    matchLabels:
+      app: upgraded
+  template:
+    metadata:
+      labels:
+        app: upgraded
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      hostPID: true
+      volumes:
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: kubelet-pki
+          hostPath:
+            path: /var/lib/kubelet/pki
+        - name: machine-id
+          hostPath:
+            path: /etc/machine-id
+      containers:
+        - name: upgraded
+          image: ghcr.io/heathcliff26/kube-upgraded:latest
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: host-run
+              mountPath: /run
+            - name: rootfs
+              mountPath: /host
+            - name: kubelet-pki
+              mountPath: /var/lib/kubelet/pki
+            - name: machine-id
+              mountPath: /etc/machine-id
+          securityContext:
+            privileged: true

--- a/examples/upgraded-config.yaml
+++ b/examples/upgraded-config.yaml
@@ -1,9 +1,9 @@
 ---
 # Used to control the log level
 logLevel: info
-# The path to the kubeconfig file
+# The path to the kubeconfig file on the node
 kubeconfig: /etc/kubernetes/kubelet.conf
 # The path to the rpm-ostree binary
 rpm-ostree-path: /usr/bin/rpm-ostree
-# The path to the kubeadm binary
+# The path to the kubeadm binary on the node
 kubeadm-path: /usr/bin/kubeadm

--- a/hack/manifests.sh
+++ b/hack/manifests.sh
@@ -26,6 +26,9 @@ export kube_upgrade_webhooks=$(envsubst <"${base_dir}/manifests/generated/manife
 echo "Creating upgrade-controller deployment"
 envsubst <"${base_dir}/manifests/base/upgrade-controller.yaml.template" >"${output_dir}/upgrade-controller.yaml"
 
+echo "Creating upgraded daemonset"
+envsubst <"${base_dir}/manifests/base/upgraded-daemonset.yaml.template" >"${output_dir}/upgraded-daemonset.yaml"
+
 echo "Fetching latest kubernetes version"
 # shellcheck disable=SC2155
 export kube_version_latest="$(curl -L -s https://dl.k8s.io/release/stable.txt)"

--- a/manifests/base/upgrade-controller.yaml.template
+++ b/manifests/base/upgrade-controller.yaml.template
@@ -10,6 +10,8 @@ kind: ServiceAccount
 metadata:
   name: upgrade-controller
   namespace: ${KUBE_UPGRADE_NAMESPACE}
+  labels:
+    app: upgrade-controller
 ${kube_upgrade_rbac_cluster_role}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,6 +19,8 @@ kind: ClusterRoleBinding
 metadata:
   name: upgrade-controller
   namespace: ${KUBE_UPGRADE_NAMESPACE}
+  labels:
+    app: upgrade-controller
 subjects:
   - kind: ServiceAccount
     name: upgrade-controller
@@ -31,6 +35,8 @@ kind: Role
 metadata:
   name: upgrade-controller
   namespace: ${KUBE_UPGRADE_NAMESPACE}
+  labels:
+    app: upgrade-controller
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -57,6 +63,8 @@ kind: Issuer
 metadata:
   name: selfsigned
   namespace: ${KUBE_UPGRADE_NAMESPACE}
+  labels:
+    app: upgrade-controller
 spec:
   selfSigned: {}
 ---
@@ -65,6 +73,8 @@ kind: Certificate
 metadata:
   name: webhook-server-cert
   namespace: ${KUBE_UPGRADE_NAMESPACE}
+  labels:
+    app: upgrade-controller
 spec:
   dnsNames:
   - upgrade-controller-webhooks.${KUBE_UPGRADE_NAMESPACE}.svc
@@ -81,16 +91,16 @@ metadata:
   name: upgrade-controller
   namespace: ${KUBE_UPGRADE_NAMESPACE}
   labels:
-    app: kube-upgrade
+    app: upgrade-controller
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: kube-upgrade
+      app: upgrade-controller
   template:
     metadata:
       labels:
-        app: kube-upgrade
+        app: upgrade-controller
     spec:
       serviceAccountName: upgrade-controller
       containers:
@@ -138,11 +148,11 @@ metadata:
   name: upgrade-controller-webhooks
   namespace: ${KUBE_UPGRADE_NAMESPACE}
   labels:
-    app: kube-upgrade
+    app: upgrade-controller
 spec:
   ports:
     - port: 443
       protocol: TCP
       targetPort: 9443
   selector:
-    app: kube-upgrade
+    app: upgrade-controller

--- a/manifests/base/upgrade-cr.yaml.template
+++ b/manifests/base/upgrade-cr.yaml.template
@@ -7,7 +7,7 @@ metadata:
 spec:
   kubernetesVersion: ${kube_version_latest}
   upgraded:
-    fleetlock-url: https://fleetlock.example.com
+    fleetlock-url: http://fleetlock.kube-upgrade.svc.cluster.local
   groups:
     control-plane:
       labels:

--- a/manifests/base/upgraded-daemonset.yaml.template
+++ b/manifests/base/upgraded-daemonset.yaml.template
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: upgraded
+  namespace: ${KUBE_UPGRADE_NAMESPACE}
+  labels:
+    app: upgraded
+spec:
+  selector:
+    matchLabels:
+      app: upgraded
+  template:
+    metadata:
+      labels:
+        app: upgraded
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      hostPID: true
+      volumes:
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: kubelet-pki
+          hostPath:
+            path: /var/lib/kubelet/pki
+        - name: machine-id
+          hostPath:
+            path: /etc/machine-id
+      containers:
+        - name: upgraded
+          image: ${REPOSITORY}/kube-upgraded:${TAG}
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: host-run
+              mountPath: /run
+            - name: rootfs
+              mountPath: /host
+            - name: kubelet-pki
+              mountPath: /var/lib/kubelet/pki
+            - name: machine-id
+              mountPath: /etc/machine-id
+          securityContext:
+            privileged: true

--- a/pkg/upgraded/config/config.go
+++ b/pkg/upgraded/config/config.go
@@ -32,11 +32,11 @@ func init() {
 type Config struct {
 	// The log level used by slog, default "info"
 	LogLevel string `json:"logLevel,omitempty"`
-	// The path to the kubeconfig file, default is the kubelet config under "/etc/kubernetes/kubelet.conf"
+	// The path to the kubeconfig file on the node, default is the kubelet config under "/etc/kubernetes/kubelet.conf"
 	Kubeconfig string `json:"kubeconfig,omitempty"`
 	// The path to the rpm-ostree binary, default "/usr/bin/rpm-ostree"
 	RPMOStreePath string `json:"rpm-ostree-path,omitempty"`
-	// The path to the kubeadm binary, default "/usr/bin/kubeadm"
+	// The path to the kubeadm binary on the node, default "/usr/bin/kubeadm"
 	KubeadmPath string `json:"kubeadm-path,omitempty"`
 }
 

--- a/pkg/upgraded/daemon/daemon.go
+++ b/pkg/upgraded/daemon/daemon.go
@@ -26,6 +26,10 @@ const (
 	defaultRetryInterval  = 1 * time.Minute
 )
 
+var (
+	hostPrefix = "/host"
+)
+
 type daemon struct {
 	fleetlock     *fleetlock.FleetlockClient
 	checkInterval time.Duration
@@ -60,7 +64,7 @@ func NewDaemon(cfg *config.Config) (*daemon, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rpm-ostree cmd wrapper: %v", err)
 	}
-	kubeadmCMD, err := kubeadm.New(cfg.KubeadmPath)
+	kubeadmCMD, err := kubeadm.New(hostPrefix, cfg.KubeadmPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubeadm cmd wrapper: %v", err)
 	}
@@ -68,7 +72,7 @@ func NewDaemon(cfg *config.Config) (*daemon, error) {
 	if cfg.Kubeconfig == "" {
 		return nil, fmt.Errorf("no kubeconfig provided")
 	}
-	config, err := clientcmd.BuildConfigFromFlags("", cfg.Kubeconfig)
+	config, err := clientcmd.BuildConfigFromFlags("", hostPrefix+cfg.Kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read kubeconfig: %v", err)
 	}

--- a/pkg/upgraded/daemon/daemon_test.go
+++ b/pkg/upgraded/daemon/daemon_test.go
@@ -16,6 +16,12 @@ import (
 )
 
 func TestNewDaemon(t *testing.T) {
+	oldHostPrefix := hostPrefix
+	hostPrefix = ""
+	t.Cleanup(func() {
+		hostPrefix = oldHostPrefix
+	})
+
 	tMatrix := []struct {
 		Name  string
 		CFG   config.Config

--- a/pkg/upgraded/daemon/node_test.go
+++ b/pkg/upgraded/daemon/node_test.go
@@ -86,7 +86,7 @@ func TestDoNodeUpgrade(t *testing.T) {
 				t.FailNow()
 			}
 
-			kubeadmCMD, err := kubeadm.New("testdata/fake-kubeadm.sh")
+			kubeadmCMD, err := kubeadm.New("", "testdata/fake-kubeadm.sh")
 			if !assert.NoError(err, "Failed to create kubeadm command") {
 				t.FailNow()
 			}

--- a/pkg/upgraded/kubeadm/kubeadm_test.go
+++ b/pkg/upgraded/kubeadm/kubeadm_test.go
@@ -11,11 +11,11 @@ import (
 func TestNew(t *testing.T) {
 	assert := assert.New(t)
 
-	cmd, err := New("not-a-file")
+	cmd, err := New("", "not-a-file")
 	assert.Error(err, "Should not succeed")
 	assert.Nil(cmd, "Should not return a command")
 
-	cmd, err = New("testdata/print-args.sh")
+	cmd, err = New("", "testdata/print-args.sh")
 	assert.NoError(err, "Should succeed")
 	assert.NotNil(cmd, "Should return a command")
 	assert.Equal("version --output short", cmd.version, "Should have set the version without newline")
@@ -24,7 +24,7 @@ func TestNew(t *testing.T) {
 func TestApply(t *testing.T) {
 	assert := assert.New(t)
 
-	cmd, err := New("testdata/print-args.sh")
+	cmd, err := New("", "testdata/print-args.sh")
 	if !assert.NoError(err, "Should create a command") {
 		t.FailNow()
 	}

--- a/pkg/upgraded/utils/utils.go
+++ b/pkg/upgraded/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 )
 
 // Read the machine-id from /etc/machine-id
@@ -22,6 +23,15 @@ func CreateCMDWithStdout(name string, arg ...string) *exec.Cmd {
 	cmd := exec.Command(name, arg...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+	return cmd
+}
+
+// Create a command that runs in a chroot and writes to stdout/stderr
+func CreateChrootCMDWithStdout(chrootPath string, name string, arg ...string) *exec.Cmd {
+	cmd := CreateCMDWithStdout(name, arg...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Chroot: chrootPath,
+	}
 	return cmd
 }
 

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -8,8 +8,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
-	"sigs.k8s.io/e2e-framework/support/kind"
 	"sigs.k8s.io/e2e-framework/pkg/utils"
+	"sigs.k8s.io/e2e-framework/support/kind"
 )
 
 const namespace = "kube-upgrade"
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	err = utils.RunCommandWithSeperatedOutput("make REPOSITORY=localhost TAG="+clusterName+" upgrade-controller", os.Stdout, os.Stderr)
+	err = utils.RunCommandWithSeperatedOutput("make REPOSITORY=localhost TAG="+clusterName+" build-upgrade-controller", os.Stdout, os.Stderr)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Run upgraded as daemonset instead of directly on the node.
Improve labels of upgrade-controller deployment.
Point to in-cluster fleetlock in CR example. This is more convenient when
upgraded is running as daemonset.
Chroot logic can't be unit-tested, as it requires root privileges.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>