### PR TITLE
api: Add field tolerations to groups to support nodes with taints

### DIFF
--- a/examples/upgrade-controller.yaml
+++ b/examples/upgrade-controller.yaml
@@ -427,6 +427,47 @@ spec:
                       description: The labels by which to filter nodes for this group
                       example: node-role.kubernetes.io/control-plane;node-role.kubernetes.io/compute
                       type: object
+                    tolerations:
+                      description: Enable the upgraded pods to be scheduled on tainted
+                        nodes like control-planes.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     upgraded:
                       description: The configuration for all upgraded daemons in the
                         group. Overwrites global parameters.

--- a/examples/upgrade-cr.yaml
+++ b/examples/upgrade-cr.yaml
@@ -12,6 +12,10 @@ spec:
     control-plane:
       labels:
         node-role.kubernetes.io/control-plane: "true"
+      tolerations:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       upgraded:
         fleetlockGroup: control-plane
     compute:

--- a/manifests/base/upgrade-cr.yaml.template
+++ b/manifests/base/upgrade-cr.yaml.template
@@ -12,6 +12,10 @@ spec:
     control-plane:
       labels:
         node-role.kubernetes.io/control-plane: "true"
+      tolerations:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
       upgraded:
         fleetlockGroup: control-plane
     compute:

--- a/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
+++ b/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml
@@ -422,6 +422,47 @@ spec:
                       description: The labels by which to filter nodes for this group
                       example: node-role.kubernetes.io/control-plane;node-role.kubernetes.io/compute
                       type: object
+                    tolerations:
+                      description: Enable the upgraded pods to be scheduled on tainted
+                        nodes like control-planes.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     upgraded:
                       description: The configuration for all upgraded daemons in the
                         group. Overwrites global parameters.

--- a/manifests/generated/kubeupgradeplan_v1alpha3.json
+++ b/manifests/generated/kubeupgradeplan_v1alpha3.json
@@ -38,6 +38,39 @@
                 "example": "node-role.kubernetes.io/control-plane;node-role.kubernetes.io/compute",
                 "type": "object"
               },
+              "tolerations": {
+                "description": "Enable the upgraded pods to be scheduled on tainted nodes like control-planes.",
+                "items": {
+                  "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                  "properties": {
+                    "effect": {
+                      "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                      "type": "string"
+                    },
+                    "key": {
+                      "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                      "type": "string"
+                    },
+                    "tolerationSeconds": {
+                      "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "value": {
+                      "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
               "upgraded": {
                 "description": "The configuration for all upgraded daemons in the group. Overwrites global parameters.",
                 "nullable": true,

--- a/pkg/apis/kubeupgrade/v1alpha3/types.go
+++ b/pkg/apis/kubeupgrade/v1alpha3/types.go
@@ -1,6 +1,7 @@
 package v1alpha3
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -68,6 +69,11 @@ type KubeUpgradePlanGroup struct {
 	// +required
 	// +kubebuilder:example="node-role.kubernetes.io/control-plane;node-role.kubernetes.io/compute"
 	Labels map[string]string `json:"labels"`
+
+	// Enable the upgraded pods to be scheduled on tainted nodes like control-planes.
+	// +optional
+	// +listType=atomic
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// The configuration for all upgraded daemons in the group. Overwrites global parameters.
 	// +optional

--- a/pkg/apis/kubeupgrade/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kubeupgrade/v1alpha3/zz_generated.deepcopy.go
@@ -6,6 +6,7 @@
 package v1alpha3
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -50,6 +51,13 @@ func (in *KubeUpgradePlanGroup) DeepCopyInto(out *KubeUpgradePlanGroup) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Upgraded != nil {

--- a/pkg/client/applyconfiguration/kubeupgrade/v1alpha3/kubeupgradeplangroup.go
+++ b/pkg/client/applyconfiguration/kubeupgrade/v1alpha3/kubeupgradeplangroup.go
@@ -2,12 +2,17 @@
 
 package v1alpha3
 
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
 // KubeUpgradePlanGroupApplyConfiguration represents a declarative configuration of the KubeUpgradePlanGroup type for use
 // with apply.
 type KubeUpgradePlanGroupApplyConfiguration struct {
-	DependsOn []string                          `json:"dependsOn,omitempty"`
-	Labels    map[string]string                 `json:"labels,omitempty"`
-	Upgraded  *UpgradedConfigApplyConfiguration `json:"upgraded,omitempty"`
+	DependsOn   []string                          `json:"dependsOn,omitempty"`
+	Labels      map[string]string                 `json:"labels,omitempty"`
+	Tolerations []v1.Toleration                   `json:"tolerations,omitempty"`
+	Upgraded    *UpgradedConfigApplyConfiguration `json:"upgraded,omitempty"`
 }
 
 // KubeUpgradePlanGroupApplyConfiguration constructs a declarative configuration of the KubeUpgradePlanGroup type for use with
@@ -36,6 +41,16 @@ func (b *KubeUpgradePlanGroupApplyConfiguration) WithLabels(entries map[string]s
 	}
 	for k, v := range entries {
 		b.Labels[k] = v
+	}
+	return b
+}
+
+// WithTolerations adds the given value to the Tolerations field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Tolerations field.
+func (b *KubeUpgradePlanGroupApplyConfiguration) WithTolerations(values ...v1.Toleration) *KubeUpgradePlanGroupApplyConfiguration {
+	for i := range values {
+		b.Tolerations = append(b.Tolerations, values[i])
 	}
 	return b
 }

--- a/pkg/upgrade-controller/controller/controller.go
+++ b/pkg/upgrade-controller/controller/controller.go
@@ -250,6 +250,7 @@ func (c *controller) reconcile(ctx context.Context, plan *api.KubeUpgradePlan, l
 		}
 		daemon.Spec = c.NewUpgradedDaemonSetSpec(plan.Name, name)
 		daemon.Spec.Template.Spec.NodeSelector = cfg.Labels
+		daemon.Spec.Template.Spec.Tolerations = cfg.Tolerations
 		if ok {
 			_, err = c.client.AppsV1().DaemonSets(c.namespace).Update(ctx, &daemon, metav1.UpdateOptions{})
 		} else {

--- a/pkg/upgrade-controller/controller/upgraded.go
+++ b/pkg/upgrade-controller/controller/upgraded.go
@@ -40,18 +40,6 @@ func (c *controller) NewUpgradedDaemonSetSpec(plan, group string) appv1.DaemonSe
 				Labels: labels,
 			},
 			Spec: corev1.PodSpec{
-				Tolerations: []corev1.Toleration{
-					{
-						Key:      "node-role.kubernetes.io/control-plane",
-						Operator: corev1.TolerationOpExists,
-						Effect:   corev1.TaintEffectNoSchedule,
-					},
-					{
-						Key:      "node-role.kubernetes.io/master",
-						Operator: corev1.TolerationOpExists,
-						Effect:   corev1.TaintEffectNoSchedule,
-					},
-				},
 				// Need to run with host PIDs for rpm-ostree to work.
 				// Otherwise it won't see the caller process PID.
 				HostPID: true,


### PR DESCRIPTION
Enable scheduling upgraded on nodes with taints by allowing users to add tolerations.