### PR TITLE
upgrade-controller: Use default values if no upgraded image is provided

### DIFF
--- a/examples/upgrade-controller.yaml
+++ b/examples/upgrade-controller.yaml
@@ -799,7 +799,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: UPGRADED_IMAGE
-              value: ghcr.io/heathcliff26/kube-upgraded:latest
+              value: ghcr.io/heathcliff26/kube-upgraded
+            - name: UPGRADED_TAG
+              value: latest
           ports:
             - name: probe
               containerPort: 9090

--- a/manifests/base/upgrade-controller.yaml.template
+++ b/manifests/base/upgrade-controller.yaml.template
@@ -118,7 +118,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: UPGRADED_IMAGE
-              value: ${REPOSITORY}/kube-upgraded:${TAG}
+              value: ${REPOSITORY}/kube-upgraded
+            - name: UPGRADED_TAG
+              value: ${TAG}
           ports:
             - name: probe
               containerPort: 9090

--- a/pkg/upgrade-controller/controller/controller.go
+++ b/pkg/upgrade-controller/controller/controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -24,6 +23,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+)
+
+const (
+	defaultUpgradedImage = "ghcr.io/heathcliff26/kube-upgraded"
+	upgradedImageEnv     = "UPGRADED_IMAGE"
+	upgradedTagEnv       = "UPGRADED_TAG"
 )
 
 func init() {
@@ -80,17 +85,12 @@ func NewController(name string) (*controller, error) {
 		return nil, err
 	}
 
-	upgradedImage := os.Getenv("UPGRADED_IMAGE")
-	if upgradedImage == "" {
-		return nil, fmt.Errorf("UPGRADED_IMAGE environment variable is not set")
-	}
-
 	return &controller{
 		Client:        mgr.GetClient(),
 		manager:       mgr,
 		client:        client,
 		namespace:     ns,
-		upgradedImage: upgradedImage,
+		upgradedImage: GetUpgradedImage(),
 	}, nil
 }
 

--- a/pkg/upgrade-controller/controller/utils.go
+++ b/pkg/upgrade-controller/controller/utils.go
@@ -3,10 +3,12 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
 	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha3"
+	"github.com/heathcliff26/kube-upgrade/pkg/version"
 )
 
 var serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
@@ -81,4 +83,19 @@ func createStatusSummary(status map[string]string) string {
 	} else {
 		return api.PlanStatusComplete
 	}
+}
+
+// Return the upgraded image to use based on environment variables
+func GetUpgradedImage() string {
+	image := os.Getenv(upgradedImageEnv)
+	tag := os.Getenv(upgradedTagEnv)
+	if image == "" {
+		slog.Info("Upgraded image is not set, falling back to default", slog.String("env", upgradedImageEnv), slog.String("image", defaultUpgradedImage))
+		image = defaultUpgradedImage
+	}
+	if tag == "" {
+		slog.Info("Upgraded image tag is not set, falling back to default", slog.String("env", upgradedTagEnv), slog.String("tag", version.Version()))
+		tag = version.Version()
+	}
+	return fmt.Sprintf("%s:%s", image, tag)
 }


### PR DESCRIPTION
When no image is provided via the environment variables, use default values
to select the correct upgraded image.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>