### PR TITLE
upgraded: Remove resolv.conf bind-mount

### DIFF
--- a/cmd/upgraded/start-upgraded.sh
+++ b/cmd/upgraded/start-upgraded.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Bind mount the container resolv.conf to prevent issues with systemd-resolved when running kubeadm in chroot
-mount --bind /etc/resolv.conf /host/etc/resolv.conf
-
 # Set the hostname in the pod to the node name.
 # This is needed for kubeadm, as it otherwise fails to find the node name.
 if [ -z "${NODE_NAME}" ]; then


### PR DESCRIPTION
Since systemd-resolved is disabled in https://github.com/heathcliff26/containers/pull/432,
the bind-mount of /etc/resolv.conf is no longer necessary and can be removed.

Fixes: #166

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>