### PR TITLE
upgraded: Split upgrade and config with separate locks

### DIFF
--- a/pkg/upgrade-controller/controller/upgraded.go
+++ b/pkg/upgrade-controller/controller/upgraded.go
@@ -88,7 +88,6 @@ func (c *controller) NewUpgradedDaemonSetSpec(plan, group string) appv1.DaemonSe
 	attachVolumeMountHostPath(&spec, "rootfs", "/", "/host")
 	// Contains certificates referenced by kubelet config.
 	attachVolumeMountHostPath(&spec, "kubelet-pki", "/var/lib/kubelet/pki", "/var/lib/kubelet/pki")
-	// TODO: This could be dropped in favour of detecting the node name via hostname in upgraded.
 	attachVolumeMountHostPath(&spec, "machine-id", "/etc/machine-id", "/etc/machine-id")
 
 	return spec

--- a/pkg/upgraded/daemon/config.go
+++ b/pkg/upgraded/daemon/config.go
@@ -41,8 +41,8 @@ func (d *daemon) updateFromConfig(cfg *api.UpgradedConfig) error {
 		return fmt.Errorf("failed to create fleetlock client with url '%s' and group '%s': %v", cfg.FleetlockURL, cfg.FleetlockGroup, err)
 	}
 
-	d.Lock()
-	defer d.Unlock()
+	d.configLock.Lock()
+	defer d.configLock.Unlock()
 
 	d.stream = cfg.Stream
 	d.fleetlock = fleetlockClient
@@ -103,4 +103,36 @@ func (d *daemon) WatchConfigFile() {
 			return
 		}
 	}
+}
+
+// Get the current stream
+func (d *daemon) Stream() string {
+	d.configLock.RLock()
+	defer d.configLock.RUnlock()
+
+	return d.stream
+}
+
+// Get the fleetlock client
+func (d *daemon) Fleetlock() *fleetlock.FleetlockClient {
+	d.configLock.RLock()
+	defer d.configLock.RUnlock()
+
+	return d.fleetlock
+}
+
+// Get the check interval
+func (d *daemon) CheckInterval() time.Duration {
+	d.configLock.RLock()
+	defer d.configLock.RUnlock()
+
+	return d.checkInterval
+}
+
+// Get the retry interval
+func (d *daemon) RetryInterval() time.Duration {
+	d.configLock.RLock()
+	defer d.configLock.RUnlock()
+
+	return d.retryInterval
 }

--- a/pkg/upgraded/daemon/stream.go
+++ b/pkg/upgraded/daemon/stream.go
@@ -39,17 +39,17 @@ func (d *daemon) watchForUpgrade() {
 		select {
 		case <-d.ctx.Done():
 			return
-		case <-time.After(d.checkInterval):
+		case <-time.After(d.CheckInterval()):
 		}
 	}
 }
 
 // Perform rpm-ostree upgrade
 func (d *daemon) doUpgrade() error {
-	d.Lock()
-	defer d.Unlock()
+	d.upgrade.Lock()
+	defer d.upgrade.Unlock()
 
-	err := d.fleetlock.Lock()
+	err := d.Fleetlock().Lock()
 	if err != nil {
 		return fmt.Errorf("failed to acquire lock: %v", err)
 	}


### PR DESCRIPTION
Ensure the configuration of the daemon can be changed while upgrade attempts
are ongoing.
This allows users to recover from a misconfiguration without restarting the
daemon.

Fixes: #158

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>