### PR TITLE
upgrade-controller: Use controller-runtime client with cache

### DIFF
--- a/examples/upgrade-controller.yaml
+++ b/examples/upgrade-controller.yaml
@@ -672,10 +672,10 @@ rules:
     verbs: ["create", "get", "update"]
   - apiGroups: ["apps"]
     resources: ["daemonsets"]
-    verbs: ["list", "create", "update", "delete"]
+    verbs: ["list", "watch", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["list", "create", "update", "delete"]
+    verbs: ["list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/base/upgrade-controller.yaml.template
+++ b/manifests/base/upgrade-controller.yaml.template
@@ -46,10 +46,10 @@ rules:
     verbs: ["create", "get", "update"]
   - apiGroups: ["apps"]
     resources: ["daemonsets"]
-    verbs: ["list", "create", "update", "delete"]
+    verbs: ["list", "watch", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["list", "create", "update", "delete"]
+    verbs: ["list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Instead of using the client-go client, switch to controller-runtime client.
This simplifies the code and allows the use of the built-in caching mechanism.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>