### PR TITLE
hack/generate.sh: Generate all roles with controller-gen

### DIFF
--- a/examples/upgrade-controller.yaml
+++ b/examples/upgrade-controller.yaml
@@ -641,6 +641,48 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: upgrade-controller
+  namespace: kube-upgrade
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - list
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: upgrade-controller
@@ -655,27 +697,6 @@ roleRef:
   kind: ClusterRole
   name: upgrade-controller
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: upgrade-controller
-  namespace: kube-upgrade
-  labels:
-    app: upgrade-controller
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["create", "get", "update"]
-  - apiGroups: ["apps"]
-    resources: ["daemonsets"]
-    verbs: ["list", "watch", "create", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["list", "watch", "create", "update", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/examples/upgrade-cr.yaml
+++ b/examples/upgrade-cr.yaml
@@ -5,7 +5,7 @@ kind: KubeUpgradePlan
 metadata:
   name: upgrade-plan
 spec:
-  kubernetesVersion: v1.34.1
+  kubernetesVersion: v1.34.2
   upgraded:
     fleetlockUrl: http://fleetlock.kube-upgrade.svc.cluster.local
   groups:

--- a/hack/manifests.sh
+++ b/hack/manifests.sh
@@ -17,7 +17,7 @@ fi
 # shellcheck disable=SC2155
 export kube_upgrade_crd=$(cat "${base_dir}/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml")
 # shellcheck disable=SC2155
-export kube_upgrade_rbac_cluster_role=$(cat "${base_dir}/manifests/generated/role.yaml")
+export kube_upgrade_rbac_cluster_role=$(envsubst <"${base_dir}/manifests/generated/role.yaml")
 # shellcheck disable=SC2155
 export kube_upgrade_webhooks=$(envsubst <"${base_dir}/manifests/generated/manifests.yaml")
 

--- a/manifests/base/upgrade-controller.yaml.template
+++ b/manifests/base/upgrade-controller.yaml.template
@@ -31,27 +31,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: upgrade-controller
-  namespace: ${KUBE_UPGRADE_NAMESPACE}
-  labels:
-    app: upgrade-controller
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["create", "get", "update"]
-  - apiGroups: ["apps"]
-    resources: ["daemonsets"]
-    verbs: ["list", "watch", "create", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["list", "watch", "create", "update", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: upgrade-controller

--- a/manifests/generated/role.yaml
+++ b/manifests/generated/role.yaml
@@ -31,3 +31,45 @@ rules:
   - get
   - patch
   - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: upgrade-controller
+  namespace: ${KUBE_UPGRADE_NAMESPACE}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - list
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update

--- a/pkg/upgrade-controller/controller/controller.go
+++ b/pkg/upgrade-controller/controller/controller.go
@@ -45,6 +45,10 @@ type controller struct {
 // +kubebuilder:rbac:groups=kubeupgrade.heathcliff.eu,resources=kubeupgradeplans,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubeupgrade.heathcliff.eu,resources=kubeupgradeplans/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list;update
+// +kubebuilder:rbac:groups="",namespace=kube-upgrade,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="coordination.k8s.io",namespace=kube-upgrade,resources=leases,verbs=create;get;update
+// +kubebuilder:rbac:groups="apps",namespace=kube-upgrade,resources=daemonsets,verbs=list;watch;create;update;delete
+// +kubebuilder:rbac:groups="",namespace=kube-upgrade,resources=configmaps,verbs=list;watch;create;update;delete
 
 func NewController(name string) (*controller, error) {
 	config, err := rest.InClusterConfig()


### PR DESCRIPTION
Manage all necessary permissions in one place.
This ensures both ClusterRole and Role are always up-to-date.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>