### PR TITLE
upgrade-controller: Only update resources when changes have been made

### DIFF
--- a/pkg/upgrade-controller/controller/upgraded.go
+++ b/pkg/upgrade-controller/controller/upgraded.go
@@ -1,8 +1,11 @@
 package controller
 
 import (
+	"context"
 	"fmt"
+	"reflect"
 
+	"github.com/go-logr/logr"
 	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha3"
 	"github.com/heathcliff26/kube-upgrade/pkg/constants"
 	upgradedconfig "github.com/heathcliff26/kube-upgrade/pkg/upgraded/config"
@@ -12,113 +15,164 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// Creates a new DaemonSet with the required metadata and no spec.
-func (c *controller) NewEmptyUpgradedDaemonSet(plan, group string) appv1.DaemonSet {
+// Creates a new DaemonSet with the required metadata and spec.
+// Caller should add node selector after creation.
+func (c *controller) NewUpgradedDaemonSet(plan, group string) *appv1.DaemonSet {
 	labels := upgradedLabels(plan, group)
 
-	return appv1.DaemonSet{
+	ds := &appv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("upgraded-%s", group),
 			Namespace: c.namespace,
 			Labels:    labels,
 		},
-	}
-}
-
-// Create a Spec template for an upgraded group.
-// Caller should add node selector after creation.
-// Used to override the DaemonSet on each reconciliation.
-func (c *controller) NewUpgradedDaemonSetSpec(plan, group string) appv1.DaemonSetSpec {
-	labels := upgradedLabels(plan, group)
-
-	spec := appv1.DaemonSetSpec{
-		Selector: &metav1.LabelSelector{
-			MatchLabels: labels,
-		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: labels,
+		Spec: appv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
 			},
-			Spec: corev1.PodSpec{
-				// Need to run with host PIDs for rpm-ostree to work.
-				// Otherwise it won't see the caller process PID.
-				HostPID: true,
-				Containers: []corev1.Container{
-					{
-						Name:  "upgraded",
-						Image: c.upgradedImage,
-						Env: []corev1.EnvVar{
-							{
-								Name: "NODE_NAME",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "spec.nodeName",
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					// Need to run with host PIDs for rpm-ostree to work.
+					// Otherwise it won't see the caller process PID.
+					HostPID: true,
+					Containers: []corev1.Container{
+						{
+							Name:  "upgraded",
+							Image: c.upgradedImage,
+							Env: []corev1.EnvVar{
+								{
+									Name: "NODE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: Pointer(true),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config",
+									MountPath: upgradedconfig.DefaultConfigDir,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: fmt.Sprintf("upgraded-%s", group),
 									},
 								},
 							},
 						},
-						SecurityContext: &corev1.SecurityContext{
-							Privileged: Pointer(true),
-						},
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "config",
-								MountPath: upgradedconfig.DefaultConfigDir,
-							},
-						},
-					},
-				},
-				Volumes: []corev1.Volume{
-					{
-						Name: "config",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: fmt.Sprintf("upgraded-%s", group),
-								},
-							},
-						},
 					},
 				},
 			},
 		},
 	}
 
-	attachVolumeMountHostPath(&spec, "host-run", "/run", "/run")
-	attachVolumeMountHostPath(&spec, "rootfs", "/", "/host")
+	attachVolumeMountHostPath(ds, "host-run", "/run", "/run")
+	attachVolumeMountHostPath(ds, "rootfs", "/", "/host")
 	// Contains certificates referenced by kubelet config.
-	attachVolumeMountHostPath(&spec, "kubelet-pki", "/var/lib/kubelet/pki", "/var/lib/kubelet/pki")
-	attachVolumeMountHostPath(&spec, "machine-id", "/etc/machine-id", "/etc/machine-id")
+	attachVolumeMountHostPath(ds, "kubelet-pki", "/var/lib/kubelet/pki", "/var/lib/kubelet/pki")
+	attachVolumeMountHostPath(ds, "machine-id", "/etc/machine-id", "/etc/machine-id")
 
-	return spec
+	return ds
 }
 
-// Creates a new ConfigMap with the required metadata and no spec.
-func (c *controller) NewEmptyUpgradedConfigMap(plan, group string) corev1.ConfigMap {
+// Creates a new ConfigMap with the required metadata and data.
+func (c *controller) NewUpgradedConfigMap(plan, group string, cfg *api.UpgradedConfig) (*corev1.ConfigMap, error) {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert upgraded config to yaml: %v", err)
+	}
+
 	labels := upgradedLabels(plan, group)
 
-	return corev1.ConfigMap{
+	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("upgraded-%s", group),
 			Namespace: c.namespace,
 			Labels:    labels,
 		},
-	}
+		Data: map[string]string{
+			upgradedconfig.DefaultConfigFile: string(data),
+		},
+	}, nil
 }
 
-// Converts the given config to a string and attaches it to the given ConfigMap data.
-func (c *controller) AttachUpgradedConfigMapData(cm *corev1.ConfigMap, cfg *api.UpgradedConfig) error {
-	data, err := yaml.Marshal(cfg)
+// Reconcile the given ConfigMap with the expected state from the given config.
+func (c *controller) reconcileUpgradedConfigMap(ctx context.Context, plan *api.KubeUpgradePlan, logger logr.Logger, cm *corev1.ConfigMap, group string) error {
+	upgradedCfg := combineConfig(plan.Spec.Upgraded, plan.Spec.Groups[group].Upgraded)
+
+	expectedCM, err := c.NewUpgradedConfigMap(plan.Name, group, upgradedCfg)
 	if err != nil {
-		return fmt.Errorf("failed to convert upgraded config to yaml: %v", err)
+		return err
 	}
 
-	cm.Data = map[string]string{upgradedconfig.DefaultConfigFile: string(data)}
+	if cm == nil {
+		logger.WithValues("group", group, "config", expectedCM.Name).Info("Creating upgraded ConfigMap for group")
+		return c.Create(ctx, expectedCM)
+	}
+
+	updated := false
+
+	if !reflect.DeepEqual(expectedCM.Labels, cm.Labels) {
+		cm.Labels = expectedCM.Labels
+		updated = true
+	}
+
+	if !reflect.DeepEqual(expectedCM.Data, cm.Data) {
+		cm.Data = expectedCM.Data
+		updated = true
+	}
+
+	if updated {
+		return c.Update(ctx, cm)
+	}
 	return nil
 }
 
-func attachVolumeMountHostPath(spec *appv1.DaemonSetSpec, name, hostPath, mountPath string) {
-	spec.Template.Spec.Volumes = append(spec.Template.Spec.Volumes, corev1.Volume{
+// Reconcile the given DaemonSet with the expected spec.
+func (c *controller) reconcileUpgradedDaemonSet(ctx context.Context, plan *api.KubeUpgradePlan, logger logr.Logger, ds *appv1.DaemonSet, groupName string, group api.KubeUpgradePlanGroup) error {
+	expectedDS := c.NewUpgradedDaemonSet(plan.Name, groupName)
+	expectedDS.Spec.Template.Spec.NodeSelector = group.Labels
+	expectedDS.Spec.Template.Spec.Tolerations = group.Tolerations
+
+	if ds == nil {
+		logger.WithValues("group", groupName, "daemon", expectedDS.Name).Info("Creating upgraded DaemonSet for group")
+		return c.Create(ctx, expectedDS)
+	}
+
+	updated := false
+
+	if !reflect.DeepEqual(expectedDS.Labels, ds.Labels) {
+		ds.Labels = expectedDS.Labels
+		updated = true
+	}
+
+	if !reflect.DeepEqual(expectedDS.Spec, ds.Spec) {
+		ds.Spec = expectedDS.Spec
+		updated = true
+	}
+
+	if updated {
+		return c.Update(ctx, ds)
+	}
+	return nil
+}
+
+func attachVolumeMountHostPath(ds *appv1.DaemonSet, name, hostPath, mountPath string) {
+	ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, corev1.Volume{
 		Name: name,
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
@@ -126,7 +180,7 @@ func attachVolumeMountHostPath(spec *appv1.DaemonSetSpec, name, hostPath, mountP
 			},
 		},
 	})
-	spec.Template.Spec.Containers[0].VolumeMounts = append(spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+	ds.Spec.Template.Spec.Containers[0].VolumeMounts = append(ds.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:      name,
 		MountPath: mountPath,
 	})

--- a/pkg/upgrade-controller/controller/upgraded_test.go
+++ b/pkg/upgrade-controller/controller/upgraded_test.go
@@ -7,23 +7,10 @@ import (
 	"github.com/heathcliff26/kube-upgrade/pkg/constants"
 	upgradedconfig "github.com/heathcliff26/kube-upgrade/pkg/upgraded/config"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNewEmptyUpgradedDaemonSet(t *testing.T) {
-	assert := assert.New(t)
-
-	c := &controller{
-		namespace: "test-namespace",
-	}
-	daemon := c.NewEmptyUpgradedDaemonSet("testplan", "testgroup")
-
-	assert.Equal("upgraded-testgroup", daemon.Name, "Should have correct name")
-	assert.Equal("test-namespace", daemon.Namespace, "Should have correct namespace")
-	assert.Equal(upgradedLabels("testplan", "testgroup"), daemon.Labels, "Should have correct labels")
-}
-
-func TestNewUpgradedDaemonSetSpec(t *testing.T) {
+func TestNewUpgradedDaemonSet(t *testing.T) {
 	assert := assert.New(t)
 
 	c := &controller{
@@ -31,46 +18,48 @@ func TestNewUpgradedDaemonSetSpec(t *testing.T) {
 		upgradedImage: "registry.example.com/kube-upgraded:latest",
 	}
 	labels := upgradedLabels("testplan", "testgroup")
-	spec := c.NewUpgradedDaemonSetSpec("testplan", "testgroup")
 
-	assert.Equal(labels, spec.Selector.MatchLabels, "Should have correct selector labels")
-	assert.Equal(labels, spec.Template.Labels, "Should have correct template labels")
-	assert.Equal(c.upgradedImage, spec.Template.Spec.Containers[0].Image, "Should have correct container image")
+	daemon := c.NewUpgradedDaemonSet("testplan", "testgroup")
 
-	for _, vol := range spec.Template.Spec.Volumes {
+	assert.Equal("upgraded-testgroup", daemon.Name, "Should have correct name")
+	assert.Equal("test-namespace", daemon.Namespace, "Should have correct namespace")
+	assert.Equal(labels, daemon.Labels, "Should have correct labels")
+
+	assert.Equal(labels, daemon.Spec.Selector.MatchLabels, "Should have correct selector labels")
+	assert.Equal(labels, daemon.Spec.Template.Labels, "Should have correct template labels")
+	assert.Equal(c.upgradedImage, daemon.Spec.Template.Spec.Containers[0].Image, "Should have correct container image")
+
+	found := false
+	for _, vol := range daemon.Spec.Template.Spec.Volumes {
 		if vol.Name == "config" {
 			assert.Equal("upgraded-testgroup", vol.ConfigMap.Name, "Should have correct config map name")
+			found = true
 			break
 		}
 	}
+	assert.True(found, "Should have config volume defined")
 }
 
-func TestAttachUpgradedConfigMapData(t *testing.T) {
-	assert := assert.New(t)
-
-	c := &controller{}
-	cm := &corev1.ConfigMap{}
-	cfg := &api.UpgradedConfig{}
-	api.SetObjectDefaults_UpgradedConfig(cfg)
-
-	assert.NoError(c.AttachUpgradedConfigMapData(cm, cfg), "Should attach config map data without error")
-	data, exists := cm.Data[upgradedconfig.DefaultConfigFile]
-	assert.True(exists, "Config map should have data for upgraded config file")
-	assert.NotEmpty(data, "Config map data for upgraded config file should not be empty")
-	assert.Contains(data, "logLevel:", "Config map data should contain logLevel field")
-}
-
-func TestNewEmptyUpgradedConfigMap(t *testing.T) {
+func TestNewUpgradedConfigMap(t *testing.T) {
 	assert := assert.New(t)
 
 	c := &controller{
 		namespace: "test-namespace",
 	}
-	cm := c.NewEmptyUpgradedConfigMap("testplan", "testgroup")
+	cfg := &api.UpgradedConfig{}
+	api.SetObjectDefaults_UpgradedConfig(cfg)
+
+	cm, err := c.NewUpgradedConfigMap("testplan", "testgroup", cfg)
+	require.NoError(t, err, "Should create upgraded config map without error")
 
 	assert.Equal("upgraded-testgroup", cm.Name, "Should have correct name")
 	assert.Equal("test-namespace", cm.Namespace, "Should have correct namespace")
 	assert.Equal(upgradedLabels("testplan", "testgroup"), cm.Labels, "Should have correct labels")
+
+	data, exists := cm.Data[upgradedconfig.DefaultConfigFile]
+	assert.True(exists, "Config map should have data for upgraded config file")
+	assert.NotEmpty(data, "Config map data for upgraded config file should not be empty")
+	assert.Contains(data, "logLevel:", "Config map data should contain logLevel field")
 }
 
 func TestUpgradedLabels(t *testing.T) {


### PR DESCRIPTION
Move the reconcile logic out of the main Reconcile function.
Only call update if changes have been made.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>