### PR TITLE
controller: Use owner references instead of finalizers

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -34,4 +34,5 @@ const (
 	LabelNodeGroup = BaseDomain + "group"
 )
 
+// TODO: Remove in future release when migration code is removed
 const Finalizer = BaseDomain + "finalizer"


### PR DESCRIPTION
Ensure created resources are owned by the KubeUpgradePlan.
This allows Kubernetes to automatically clean up resources when the plan is
deleted, removing the need for finalizers and related cleanup logic.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>