### PR TITLE
manifests: Add watch permission for nodes

### DIFF
--- a/examples/upgrade-controller.yaml
+++ b/examples/upgrade-controller.yaml
@@ -269,6 +269,7 @@ rules:
   verbs:
   - list
   - update
+  - watch
 - apiGroups:
   - kubeupgrade.heathcliff.eu
   resources:

--- a/manifests/generated/role.yaml
+++ b/manifests/generated/role.yaml
@@ -11,6 +11,7 @@ rules:
   verbs:
   - list
   - update
+  - watch
 - apiGroups:
   - kubeupgrade.heathcliff.eu
   resources:

--- a/pkg/upgrade-controller/controller/controller.go
+++ b/pkg/upgrade-controller/controller/controller.go
@@ -44,7 +44,7 @@ type controller struct {
 // Run make generate when changing these comments
 // +kubebuilder:rbac:groups=kubeupgrade.heathcliff.eu,resources=kubeupgradeplans,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubeupgrade.heathcliff.eu,resources=kubeupgradeplans/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=nodes,verbs=list;update
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch;update
 // +kubebuilder:rbac:groups="",namespace=kube-upgrade,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups="coordination.k8s.io",namespace=kube-upgrade,resources=leases,verbs=create;get;update
 // +kubebuilder:rbac:groups="apps",namespace=kube-upgrade,resources=daemonsets,verbs=list;watch;create;update;delete


### PR DESCRIPTION
Ensure nodes can be watched for changes by the controller.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>