### PR TITLE
upgrade-controller: Add more verbose logging

### DIFF
--- a/pkg/upgrade-controller/controller/controller_test.go
+++ b/pkg/upgrade-controller/controller/controller_test.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -473,7 +473,7 @@ func TestReconcile(t *testing.T) {
 
 			ctx := t.Context()
 
-			err := c.reconcile(ctx, &tCase.Plan, klog.NewKlogr())
+			err := c.reconcile(ctx, &tCase.Plan, ctrl.Log)
 
 			if !assert.NoError(err, "Reconcile should succeed") {
 				t.FailNow()
@@ -602,7 +602,7 @@ func TestReconcileUpgradedDaemons(t *testing.T) {
 				addFakeUpgradedDaemonset(t, c, plan.Name, group)
 			}
 
-			assert.NoError(c.reconcile(t.Context(), plan, klog.NewKlogr()), "Reconcile should succeed")
+			assert.NoError(c.reconcile(t.Context(), plan, ctrl.Log), "Reconcile should succeed")
 
 			dsList := &appv1.DaemonSetList{}
 			err := c.List(t.Context(), dsList, client.InNamespace(c.namespace))
@@ -651,7 +651,7 @@ func TestReconcileUpgradedDaemons(t *testing.T) {
 		daemon.Spec.Template.Spec.HostPID = false
 		_ = c.Create(t.Context(), daemon)
 
-		assert.NoError(c.reconcile(t.Context(), plan, klog.NewKlogr()), "Reconcile should succeed")
+		assert.NoError(c.reconcile(t.Context(), plan, ctrl.Log), "Reconcile should succeed")
 
 		err := c.Get(t.Context(), client.ObjectKeyFromObject(daemon), daemon)
 		assert.NoError(err, "Should get daemonset without error")
@@ -683,7 +683,7 @@ func TestReconcileUpgradedDaemons(t *testing.T) {
 		cm, _ := c.NewUpgradedConfigMap(plan.Name, groupControl, cfg)
 		_ = c.Create(t.Context(), cm)
 
-		assert.NoError(c.reconcile(t.Context(), plan, klog.NewKlogr()), "Reconcile should succeed")
+		assert.NoError(c.reconcile(t.Context(), plan, ctrl.Log), "Reconcile should succeed")
 
 		err := c.Get(t.Context(), client.ObjectKeyFromObject(cm), cm)
 		assert.NoError(err, "Should get daemonset without error")
@@ -710,7 +710,7 @@ func TestFinalizerMigration(t *testing.T) {
 	controllerutil.AddFinalizer(plan, constants.Finalizer)
 	c := createFakeController(nil, nil, nil, plan)
 
-	assert.NoError(c.reconcile(t.Context(), plan, klog.NewKlogr()), "First reconcile should succeed")
+	assert.NoError(c.reconcile(t.Context(), plan, ctrl.Log), "First reconcile should succeed")
 	assert.NotContains(plan.GetFinalizers(), constants.Finalizer, "Plan should not have finalizer after first reconcile")
 }
 

--- a/pkg/upgrade-controller/controller/log.go
+++ b/pkg/upgrade-controller/controller/log.go
@@ -1,0 +1,48 @@
+package controller
+
+import (
+	"flag"
+	"os"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const logLevelEnv = "LOG_LEVEL"
+
+const (
+	logLevelDebug = 4
+	logLevelInfo  = 0
+	logLevelWarn  = -4
+)
+
+func init() {
+	var fs flag.FlagSet
+	klog.InitFlags(&fs)
+	err := fs.Set("v", strconv.Itoa(getLogLevel()))
+	if err != nil {
+		klog.Fatalf("Failed to set klog verbosity: %v", err)
+	}
+	logger := klog.NewKlogr()
+	ctrl.SetLogger(logger)
+	logger.WithValues(logLevelEnv, os.Getenv(logLevelEnv), "level", getLogLevel()).Info("Logger initialized")
+}
+
+func getLogLevel() int {
+	levelStr := os.Getenv(logLevelEnv)
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return logLevelDebug
+	case "info":
+		return logLevelInfo
+	case "warn":
+		return logLevelWarn
+	case "":
+		return logLevelInfo
+	default:
+		klog.Warningf("Unknown log level '%s', defaulting to 'info'", levelStr)
+		return logLevelInfo
+	}
+}

--- a/pkg/upgrade-controller/controller/log_test.go
+++ b/pkg/upgrade-controller/controller/log_test.go
@@ -1,0 +1,28 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLogLevel(t *testing.T) {
+	tMatrix := map[string]int{
+		"debug":   logLevelDebug,
+		"info":    logLevelInfo,
+		"warn":    logLevelWarn,
+		"unknown": logLevelInfo,
+		"Debug":   logLevelDebug,
+		"WARN":    logLevelWarn,
+	}
+	for levelStr, logLevel := range tMatrix {
+		t.Run(levelStr, func(t *testing.T) {
+			t.Setenv(logLevelEnv, levelStr)
+			assert.Equal(t, logLevel, getLogLevel(), "Should return correct log level")
+		})
+	}
+	t.Run("VariableEmpty", func(t *testing.T) {
+		t.Setenv(logLevelEnv, "")
+		assert.Equal(t, logLevelInfo, getLogLevel(), "Should return default value")
+	})
+}

--- a/pkg/upgrade-controller/controller/upgraded.go
+++ b/pkg/upgrade-controller/controller/upgraded.go
@@ -124,8 +124,10 @@ func (c *controller) reconcileUpgradedConfigMap(ctx context.Context, plan *api.K
 		return err
 	}
 
+	logger = logger.WithValues("config", expectedCM.Name)
+
 	if cm == nil {
-		logger.WithValues("group", group, "config", expectedCM.Name).Info("Creating upgraded ConfigMap for group")
+		logger.Info("Creating upgraded ConfigMap for group")
 		return c.Create(ctx, expectedCM)
 	}
 
@@ -147,6 +149,7 @@ func (c *controller) reconcileUpgradedConfigMap(ctx context.Context, plan *api.K
 	}
 
 	if updated {
+		logger.V(logLevelDebug).Info("Updating ConfigMap")
 		return c.Update(ctx, cm)
 	}
 	return nil
@@ -162,8 +165,10 @@ func (c *controller) reconcileUpgradedDaemonSet(ctx context.Context, plan *api.K
 		return err
 	}
 
+	logger = logger.WithValues("daemon", expectedDS.Name)
+
 	if ds == nil {
-		logger.WithValues("group", groupName, "daemon", expectedDS.Name).Info("Creating upgraded DaemonSet for group")
+		logger.Info("Creating upgraded DaemonSet for group")
 		return c.Create(ctx, expectedDS)
 	}
 
@@ -185,6 +190,7 @@ func (c *controller) reconcileUpgradedDaemonSet(ctx context.Context, plan *api.K
 	}
 
 	if updated {
+		logger.V(logLevelDebug).Info("Updating Daemonset")
 		return c.Update(ctx, ds)
 	}
 	return nil

--- a/pkg/upgrade-controller/controller/utils.go
+++ b/pkg/upgrade-controller/controller/utils.go
@@ -3,12 +3,12 @@ package controller
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 
 	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha3"
 	"github.com/heathcliff26/kube-upgrade/pkg/version"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
@@ -87,14 +87,16 @@ func createStatusSummary(status map[string]string) string {
 
 // Return the upgraded image to use based on environment variables
 func GetUpgradedImage() string {
+	logger := ctrl.Log
+
 	image := os.Getenv(upgradedImageEnv)
 	tag := os.Getenv(upgradedTagEnv)
 	if image == "" {
-		slog.Info("Upgraded image is not set, falling back to default", slog.String("env", upgradedImageEnv), slog.String("image", defaultUpgradedImage))
+		logger.WithValues("env", upgradedImageEnv, "image", defaultUpgradedImage).Info("Upgraded image is not set, falling back to default")
 		image = defaultUpgradedImage
 	}
 	if tag == "" {
-		slog.Info("Upgraded image tag is not set, falling back to default", slog.String("env", upgradedTagEnv), slog.String("tag", version.Version()))
+		logger.WithValues("env", upgradedTagEnv, "tag", version.Version()).Info("Upgraded image tag is not set, falling back to default")
 		tag = version.Version()
 	}
 	return fmt.Sprintf("%s:%s", image, tag)


### PR DESCRIPTION
Enable more verbose logging by allowing configuration of log levels via
environment variable.
Fix e2e test overwriting kubeconfig.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>