### PR TITLE
upgrade-controller: Only reconcile DaemonSet when it changed

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,9 +1,9 @@
 package constants
 
 const (
-	BaseDomain   = "kube-upgrade.heathcliff.eu/"
-	NodePrefix   = "node." + BaseDomain
-	ConfigPrefix = "config." + BaseDomain
+	BaseDomain       = "kube-upgrade.heathcliff.eu/"
+	NodePrefix       = "node." + BaseDomain
+	ControllerPrefix = "controller." + BaseDomain
 )
 
 const (
@@ -23,6 +23,10 @@ const (
 const (
 	LabelPlanName  = BaseDomain + "plan"
 	LabelNodeGroup = BaseDomain + "group"
+)
+
+const (
+	ControllerResourceHash = ControllerPrefix + "checksum"
 )
 
 // TODO: Remove in future release when migration code is removed

--- a/pkg/upgrade-controller/controller/controller_test.go
+++ b/pkg/upgrade-controller/controller/controller_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	groupControl    = "control"
+	groupControl    = "control-plane"
 	labelControl    = "node-role.kubernetes.io/control-plane"
 	nodeControlName = "node-control"
 
@@ -76,7 +76,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSummary: api.PlanStatusProgressing + ": Upgrading groups [control]",
+			ExpectedSummary: api.PlanStatusProgressing + ": Upgrading groups [control-plane]",
 			ExpectedGroupStatus: map[string]string{
 				groupControl: api.PlanStatusProgressing + ": 0/1 nodes upgraded",
 				groupCompute: api.PlanStatusWaiting,
@@ -110,7 +110,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				Status: api.KubeUpgradeStatus{
-					Summary: api.PlanStatusProgressing + ": Upgrading groups [control]",
+					Summary: api.PlanStatusProgressing + ": Upgrading groups [control-plane]",
 					Groups: map[string]string{
 						groupControl: api.PlanStatusProgressing + ": 0/1 nodes upgraded",
 						groupCompute: api.PlanStatusWaiting,
@@ -291,7 +291,7 @@ func TestReconcile(t *testing.T) {
 				constants.NodeKubernetesVersion: "v1.30.4",
 				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusCompleted,
 			},
-			ExpectedSummary: api.PlanStatusProgressing + ": Upgrading groups [control]",
+			ExpectedSummary: api.PlanStatusProgressing + ": Upgrading groups [control-plane]",
 			ExpectedGroupStatus: map[string]string{
 				groupControl: api.PlanStatusProgressing + ": 0/1 nodes upgraded",
 				groupCompute: api.PlanStatusWaiting,
@@ -324,7 +324,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				Status: api.KubeUpgradeStatus{
-					Summary: api.PlanStatusProgressing + ": Upgrading groups [control]",
+					Summary: api.PlanStatusProgressing + ": Upgrading groups [control-plane]",
 					Groups: map[string]string{
 						groupControl: api.PlanStatusProgressing + ": 0/1 nodes upgraded",
 						groupCompute: api.PlanStatusWaiting,
@@ -424,7 +424,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSummary: api.PlanStatusProgressing + ": Upgrading groups [control]",
+			ExpectedSummary: api.PlanStatusProgressing + ": Upgrading groups [control-plane]",
 			ExpectedGroupStatus: map[string]string{
 				groupControl: api.PlanStatusProgressing + ": 0/1 nodes upgraded",
 				groupCompute: api.PlanStatusWaiting,
@@ -454,7 +454,7 @@ func TestReconcile(t *testing.T) {
 				constants.NodeKubernetesVersion: "v1.31.0",
 				constants.NodeUpgradeStatus:     constants.NodeUpgradeStatusError,
 			},
-			ExpectedSummary: api.PlanStatusError + ": Some groups encountered errors [control]",
+			ExpectedSummary: api.PlanStatusError + ": Some groups encountered errors [control-plane]",
 			ExpectedGroupStatus: map[string]string{
 				groupControl: api.PlanStatusError + ": The nodes [node-control] are reporting errors",
 			},


### PR DESCRIPTION
Use hashes to check if the spec changed.
This should reduce the amount of updates.

Fixes: #186

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>