### PR TITLE
upgrade-controller: Use validating webhook to ensure only a single plan exists

### DIFF
--- a/pkg/upgrade-controller/controller/controller_test.go
+++ b/pkg/upgrade-controller/controller/controller_test.go
@@ -11,9 +11,7 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -715,9 +713,7 @@ func TestFinalizerMigration(t *testing.T) {
 }
 
 func createFakeController(annotationsControl, annotationsCompute, annotationsInfra map[string]string, plan *api.KubeUpgradePlan) *controller {
-	scheme := runtime.NewScheme()
-	_ = api.AddToScheme(scheme)
-	_ = clientgoscheme.AddToScheme(scheme)
+	scheme, _ := newScheme()
 
 	nodeControl := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/upgrade-controller/controller/utils.go
+++ b/pkg/upgrade-controller/controller/utils.go
@@ -9,6 +9,8 @@ import (
 
 	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha3"
 	"github.com/heathcliff26/kube-upgrade/pkg/version"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 var serviceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
@@ -100,4 +102,18 @@ func GetUpgradedImage() string {
 		tag = version.Version()
 	}
 	return fmt.Sprintf("%s:%s", image, tag)
+}
+
+// Return a new scheme with already registered standard types and kube-upgrade types
+func newScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := api.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = clientgoscheme.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	return scheme, nil
 }

--- a/pkg/upgrade-controller/controller/validatingwebhook.go
+++ b/pkg/upgrade-controller/controller/validatingwebhook.go
@@ -3,16 +3,20 @@ package controller
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	api "github.com/heathcliff26/kube-upgrade/pkg/apis/kubeupgrade/v1alpha3"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // +kubebuilder:webhook:path=/validate-kubeupgrade-heathcliff-eu-v1alpha3-kubeupgradeplan,mutating=false,failurePolicy=fail,groups=kubeupgrade.heathcliff.eu,resources=kubeupgradeplans,verbs=create;update,versions=v1alpha3,name=kubeupgrade.heathcliff.eu,admissionReviewVersions=v1,sideEffects=None
 
 // planValidatingHook validates the plan
-type planValidatingHook struct{}
+type planValidatingHook struct {
+	client.Client
+}
 
 // Validate all values of the plan and check if they are sensible
 func (*planValidatingHook) validate(obj runtime.Object) (admission.Warnings, error) {
@@ -32,7 +36,21 @@ func (*planValidatingHook) validate(obj runtime.Object) (admission.Warnings, err
 // ValidateCreate validates the object on creation.
 // The optional warnings will be added to the response as warning messages.
 // Return an error if the object is invalid.
-func (p *planValidatingHook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (p *planValidatingHook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if p.Client == nil {
+		return nil, fmt.Errorf("no client provided for validating webhook, please report a bug")
+	}
+
+	planList := &api.KubeUpgradePlanList{}
+	err := p.List(ctx, planList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list KubeUpgradePlans: %v", err)
+	}
+	if len(planList.Items) > 0 {
+		slog.With("existing-plan", planList.Items[0].Name).Warn("Attempted to create a KubeUpgradePlan, but one already exists")
+		return nil, fmt.Errorf("KubeUpgradePlan already exists")
+	}
+
 	return p.validate(obj)
 }
 


### PR DESCRIPTION
There should only ever be a single KubeUpgradePlan in the cluster at any time.
To enforce this, add a validating webhook that checks for existing plans
when a new plan is created, and rejects the creation if one already exists.

Closes: #187

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>