### PR TITLE
helm: Add fleetlock as optional dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp_image_kube-upgrade-e2e-*.tar
 
 # Ignore helm chart packages
 /kube-upgrade-*.tgz
+/manifests/helm/charts

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Kubernetes controller and daemon for managing cluster updates.
 
 ### Installation
 
-To install kube-upgrade, follow these steps:
+You can install kube-upgrade using the [helm chart](manifests/helm/).
+
+To install kube-upgrade using kubectl, follow these steps:
 1. Deploy **upgrade-controller**
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/heathcliff26/kube-upgrade/main/examples/upgrade-controller.yaml

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -4,7 +4,7 @@ set -e
 
 base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
 
-folders=("bin" "manifests/release" "coverprofiles" "logs")
+folders=("bin" "manifests/release" "coverprofiles" "logs" "manifests/helm/charts")
 files=("coverprofile.out")
 
 for folder in "${folders[@]}"; do

--- a/hack/manifests.sh
+++ b/hack/manifests.sh
@@ -31,6 +31,8 @@ EOF
 echo "  name: ${KUBE_UPGRADE_NAMESPACE}" >> "${upgrade_controller_file}"
 cat "${base_dir}/manifests/generated/kubeupgrade.heathcliff.eu_kubeupgradeplans.yaml" >> "${upgrade_controller_file}"
 
+helm dependency build "${base_dir}/manifests/helm"
+
 helm template "${base_dir}/manifests/helm" \
     --debug \
     --set fullnameOverride=kube-upgrade \

--- a/manifests/helm/Chart.lock
+++ b/manifests/helm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: fleetlock
+  repository: oci://ghcr.io/heathcliff26/manifests
+  version: v1.8.0
+digest: sha256:c65751481bfce0ea23bab80d2943f5016fb70430454b82d74b86880110c23955
+generated: "2025-11-17T19:38:18.959700925+01:00"

--- a/manifests/helm/Chart.yaml
+++ b/manifests/helm/Chart.yaml
@@ -20,3 +20,9 @@ sources:
   - https://github.com/heathcliff26/kube-upgrade
 
 kubeVersion: ">= 1.32.0"
+
+dependencies:
+  - name: fleetlock
+    version: v1.8.0
+    repository: oci://ghcr.io/heathcliff26/manifests
+    condition: fleetlock.enabled

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -80,3 +80,8 @@ webhooks:
 # RBAC configuration
 rbac:
   create: true
+
+# Fleetlock dependency configuration
+fleetlock:
+  # Deploy fleetlock server
+  enabled: false


### PR DESCRIPTION
Allow users to additionally deploy fleetlock along with kube-upgrade via
the helm chart.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>