### PR TITLE
Harden deployments through security context

### DIFF
--- a/examples/upgrade-controller.yaml
+++ b/examples/upgrade-controller.yaml
@@ -433,6 +433,15 @@ spec:
       serviceAccountName: kube-upgrade
       containers:
         - name: upgrade-controller
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           image: "ghcr.io/heathcliff26/kube-upgrade-controller:latest"
           imagePullPolicy: IfNotPresent
           env:

--- a/examples/upgrade-cr.yaml
+++ b/examples/upgrade-cr.yaml
@@ -5,7 +5,7 @@ kind: KubeUpgradePlan
 metadata:
   name: upgrade-plan
 spec:
-  kubernetesVersion: v1.35.2
+  kubernetesVersion: v1.35.3
   upgraded:
     fleetlockUrl: http://fleetlock.kube-upgrade.svc.cluster.local
   groups:

--- a/manifests/helm/templates/deployment.yaml
+++ b/manifests/helm/templates/deployment.yaml
@@ -29,10 +29,15 @@ spec:
       {{- end }}
       containers:
         - name: upgrade-controller
-          {{- with .Values.upgradeController.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           image: "{{ .Values.upgradeController.repository }}:{{ .Values.upgradeController.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.upgradeController.pullPolicy }}
           env:

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -21,14 +21,6 @@ upgradeController:
   labels: {}
   # This is for setting the pod security context.
   podSecurityContext: {}
-  # This is for setting the container security context.
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
   # This is to setup resource requests and limits.
   resources:
     requests:

--- a/pkg/upgrade-controller/controller/upgraded.go
+++ b/pkg/upgrade-controller/controller/upgraded.go
@@ -59,12 +59,17 @@ func (c *controller) NewUpgradedDaemonSet(plan, group string) *appv1.DaemonSet {
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: Pointer(true),
+								Privileged:             Pointer(true),
+								ReadOnlyRootFilesystem: Pointer(true),
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "config",
 									MountPath: upgradedconfig.DefaultConfigDir,
+								},
+								{
+									Name:      "tmp",
+									MountPath: "/tmp",
 								},
 							},
 							Resources: corev1.ResourceRequirements{
@@ -86,6 +91,12 @@ func (c *controller) NewUpgradedDaemonSet(plan, group string) *appv1.DaemonSet {
 										Name: fmt.Sprintf("upgraded-%s", group),
 									},
 								},
+							},
+						},
+						{
+							Name: "tmp",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},


### PR DESCRIPTION
Harden controller through hardcoding the securityContext. Make upgraded root filesystem readonly.