### PR TITLE
Ignore gosec G204 error for helper function

### DIFF
--- a/pkg/upgraded/utils/utils.go
+++ b/pkg/upgraded/utils/utils.go
@@ -20,6 +20,7 @@ func GetMachineID() (string, error) {
 
 // Create a command that writes to stdout/stderr
 func CreateCMDWithStdout(name string, arg ...string) *exec.Cmd {
+	// #nosec G204: Intended design
 	cmd := exec.Command(name, arg...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Need to launch multiple external binaries. As such the binary path is intended to be a variable.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>